### PR TITLE
[deploy] get image from ghcr

### DIFF
--- a/deployments/docker-swarm-terraform/main.tf
+++ b/deployments/docker-swarm-terraform/main.tf
@@ -7,7 +7,7 @@ data "docker_network" "internal" {
 }
 
 resource "docker_image" "app" {
-  name         = "capcom6/${var.app-name}:${var.app-version}"
+  name         = "ghcr.io/android-sms-gateway/server:${var.app-version}"
   keep_locally = true
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- The Docker deployment now sources its container image from a new GitHub Container Registry, ensuring updated infrastructure while maintaining existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->