### PR TITLE
[api] move devices registration rate limit to Traefik

### DIFF
--- a/internal/sms-gateway/handlers/mobile.go
+++ b/internal/sms-gateway/handlers/mobile.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/keyauth"
-	"github.com/gofiber/fiber/v2/middleware/limiter"
 	"github.com/jaevor/go-nanoid"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
@@ -232,7 +231,6 @@ func (h *mobileHandler) Register(router fiber.Router) {
 	router = router.Group("/mobile/v1")
 
 	router.Post("/device",
-		limiter.New(),
 		userauth.New(h.authSvc),
 		keyauth.New(keyauth.Config{
 			Next: func(c *fiber.Ctx) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced service routing with refined rate limiting and API path prefix handling for improved request management.
  
- **Bug Fixes**
  - Removed rate limiting from the device registration endpoint to improve accessibility and streamline performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->