### PR TITLE
[config] expose database pool options to config

### DIFF
--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -13,6 +13,8 @@ database: # database
   password: root # database password [DATABASE__PASSWORD]
   database: sms # database name [DATABASE__DATABASE]
   timezone: UTC # database timezone (important for message TTL calculation) [DATABASE__TIMEZONE]
+  max_open_conns: 4 # database max open connections (default: 4 * CPU) [DATABASE__MAX_OPEN_CONNS]
+  max_idle_conns: 2 # database max idle connections (default: 2 * CPU) [DATABASE__MAX_IDLE_CONNS]
 fcm: # firebase cloud messaging config
   credentials_json: "{}" # firebase credentials json (for public mode only) [FCM__CREDENTIALS_JSON]
   timeout_seconds: 1 # push notification send timeout [FCM__DEBOUNCE_SECONDS]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,9 @@ type Database struct {
 	Database string `yaml:"database" envconfig:"DATABASE__DATABASE"` // database name
 	Timezone string `yaml:"timezone" envconfig:"DATABASE__TIMEZONE"` // database timezone
 	Debug    bool   `yaml:"debug"    envconfig:"DATABASE__DEBUG"`    // debug mode
+
+	MaxOpenConns int `yaml:"max_open_conns" envconfig:"DATABASE__MAX_OPEN_CONNS"` // max open connections
+	MaxIdleConns int `yaml:"max_idle_conns" envconfig:"DATABASE__MAX_IDLE_CONNS"` // max idle connections
 }
 
 type FCMConfig struct {

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -42,6 +42,9 @@ var Module = fx.Module(
 			Database: cfg.Database.Database,
 			Timezone: cfg.Database.Timezone,
 			Debug:    cfg.Database.Debug,
+
+			MaxOpenConns: cfg.Database.MaxOpenConns,
+			MaxIdleConns: cfg.Database.MaxIdleConns,
 		}
 	}),
 	fx.Provide(func(cfg Config) push.Config {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two new database configuration options visible in the sample configuration file: one for controlling the maximum number of open connections (default: 4) and another for specifying the maximum number of idle connections (default: 2). These options offer enhanced control over connection pooling, enabling improved performance and resource management for database connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->