### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # step 1: checkout repository code
       - name: Checkout code into workspace directory
@@ -29,6 +31,8 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       # step 1: checkout repository code
       - name: Checkout code into workspace directory


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/server/security/code-scanning/6](https://github.com/android-sms-gateway/server/security/code-scanning/6)

To fix the issue, we need to explicitly define the `permissions` block for the `test` and `e2e` jobs. Since these jobs only involve checking out code, setting up Go, installing dependencies, and running tests, they likely only require `contents: read` permissions. Adding this minimal permission ensures that the workflow adheres to the principle of least privilege.

The `permissions` block should be added to the `test` and `e2e` jobs, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for test and end-to-end jobs to ensure proper access during automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->