### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - build
 


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/server/security/code-scanning/7](https://github.com/android-sms-gateway/server/security/code-scanning/7)

To fix the issue, we need to explicitly define a `permissions` block for the `deploy` job. Since the `deploy` job does not appear to require any write permissions, we can set the permissions to `contents: read`, which is the minimal required permission for most workflows. This ensures that the `GITHUB_TOKEN` has only the necessary access, reducing the risk of unintended actions.

The changes will be made in the `.github/workflows/release.yml` file, specifically within the `deploy` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal deployment workflow configuration. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->