### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,4 +1,6 @@
 name: Terraform Validate
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/server/security/code-scanning/9](https://github.com/android-sms-gateway/server/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the minimal permissions required. Since the workflow only needs to read repository contents (e.g., to check out code), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has the least privileges necessary to complete the workflow tasks.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to grant read access to repository contents for Terraform validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->