### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -98,6 +98,10 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: read
     needs:
       - build
     outputs:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/server/security/code-scanning/10](https://github.com/android-sms-gateway/server/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `merge` job. Based on the actions performed in the `merge` job, the minimal required permissions are:
- `contents: read` to access repository contents.
- `packages: write` to interact with Docker registries.
- `actions: read` to download artifacts.

This ensures that the `merge` job has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
