### PR TITLE
[messages] explicit device selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.2
 
 require (
 	firebase.google.com/go/v4 v4.12.1
-	github.com/android-sms-gateway/client-go v1.8.1
+	github.com/android-sms-gateway/client-go v1.8.2
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/capcom6/go-helpers v0.3.0
 	github.com/capcom6/go-infra-fx v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.2
 
 require (
 	firebase.google.com/go/v4 v4.12.1
-	github.com/android-sms-gateway/client-go v1.8.2
+	github.com/android-sms-gateway/client-go v1.8.3-0.20250708235905-d5c9b879467b
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/capcom6/go-helpers v0.3.0
 	github.com/capcom6/go-infra-fx v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.2
 
 require (
 	firebase.google.com/go/v4 v4.12.1
-	github.com/android-sms-gateway/client-go v1.8.3-0.20250708235905-d5c9b879467b
+	github.com/android-sms-gateway/client-go v1.9.1
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/capcom6/go-helpers v0.3.0
 	github.com/capcom6/go-infra-fx v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -26,12 +26,10 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/android-sms-gateway/client-go v1.7.1-0.20250629114454-6a0c4d8bb90a h1:dAMTNI56fW8l5RrrwYUrvibIkpRCFw9jEFkjEw6mDMQ=
-github.com/android-sms-gateway/client-go v1.7.1-0.20250629114454-6a0c4d8bb90a/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.8.1-0.20250701232650-4956a99b0da7 h1:rOBF445neI27pKcndrC3lH7buN8HrRvYvdVWCjFIsHg=
-github.com/android-sms-gateway/client-go v1.8.1-0.20250701232650-4956a99b0da7/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.8.1 h1:cakQc4aw7oBKbcdCJsbP1HjM2BZouYSIKHRwHzBo2TY=
-github.com/android-sms-gateway/client-go v1.8.1/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.8.2-0.20250703013756-220a21ca308a h1:ujqQmJRby629m4R9CTv3N8d5Hyc3Qrd8Sj81EmFigh0=
+github.com/android-sms-gateway/client-go v1.8.2-0.20250703013756-220a21ca308a/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.8.2 h1:uywKRE9j1UL+u9e8k4MDg7qri0RFN+4lSdR9ZYd7vSo=
+github.com/android-sms-gateway/client-go v1.8.2/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,14 @@ github.com/android-sms-gateway/client-go v1.8.2 h1:uywKRE9j1UL+u9e8k4MDg7qri0RFN
 github.com/android-sms-gateway/client-go v1.8.2/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/android-sms-gateway/client-go v1.8.3-0.20250708235905-d5c9b879467b h1:1gbDvRyHzSx3A9l9A1G1xPIcHjswLoi3Q5/5W1Izn4s=
 github.com/android-sms-gateway/client-go v1.8.3-0.20250708235905-d5c9b879467b/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.8.3-0.20250709075837-b56390c5805f h1:dNNJb23fD5FWR8rEAfDD/E++PqeX0qvrykaI86r71DM=
+github.com/android-sms-gateway/client-go v1.8.3-0.20250709075837-b56390c5805f/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.8.3-0.20250709231222-49a14b8eaeb3 h1:vp1E56k/LBwqOOyVYdtjrshkGiK0TZ1vIAka0tuJW3w=
+github.com/android-sms-gateway/client-go v1.8.3-0.20250709231222-49a14b8eaeb3/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.9.1-0.20250710073217-459eb6749b27 h1:KIj7aZF+tJn9j0X0QFAVAZf2o1/VDwdR+Zt7ksy4aEw=
+github.com/android-sms-gateway/client-go v1.9.1-0.20250710073217-459eb6749b27/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.9.1 h1:i9hKf+kgaJo9ykWKoeno3MliOThoIlwO0N2eed6bY+Q=
+github.com/android-sms-gateway/client-go v1.9.1/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/capcom6/go-helpers v0.2.1-0.20250630235533-8457c7435058 h1:tt64ezShwdmcUk04gBVL1BD49FDAfVZ4ELiw2rrJp+I=
-github.com/capcom6/go-helpers v0.2.1-0.20250630235533-8457c7435058/go.mod h1:WDqc7HZNqHxUTisArkYIBZtqUfJBVyPWeQI+FMwEzAw=
 github.com/capcom6/go-helpers v0.3.0 h1:ae18fLfluoPubiB2V+j4cIpfZaTuK4acS2entamaDkE=
 github.com/capcom6/go-helpers v0.3.0/go.mod h1:WDqc7HZNqHxUTisArkYIBZtqUfJBVyPWeQI+FMwEzAw=
 github.com/capcom6/go-infra-fx v0.2.1 h1:8rqr2ZV+YC2R07amHMdlE1XKLUhMe5yO+ffCJ/xXlNY=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/android-sms-gateway/client-go v1.8.2-0.20250703013756-220a21ca308a h1
 github.com/android-sms-gateway/client-go v1.8.2-0.20250703013756-220a21ca308a/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/android-sms-gateway/client-go v1.8.2 h1:uywKRE9j1UL+u9e8k4MDg7qri0RFN+4lSdR9ZYd7vSo=
 github.com/android-sms-gateway/client-go v1.8.2/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.8.3-0.20250708235905-d5c9b879467b h1:1gbDvRyHzSx3A9l9A1G1xPIcHjswLoi3Q5/5W1Izn4s=
+github.com/android-sms-gateway/client-go v1.8.3-0.20250708235905-d5c9b879467b/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -40,13 +40,13 @@ type ThirdPartyController struct {
 }
 
 //	@Summary		Enqueue message
-//	@Description	Enqueues message for sending. If multiple devices are registered, it will be sent via a random one
+//	@Description	Enqueues a message for sending. If `deviceId` is set, the specified device is used; otherwise a random registered device is chosen.
 //	@Security		ApiAuth
 //	@Tags			User, Messages
 //	@Accept			json
 //	@Produce		json
 //	@Param			skipPhoneValidation		query		bool							false	"Skip phone validation"
-//	@Param			deviceActiveWithin		query		int								false	"Filter devices active within the specified number of hours"	default(0)
+//	@Param			deviceActiveWithin		query		int								false	"Filter devices active within the specified number of hours"	default(0)	minimum(0)
 //	@Param			request					body		smsgateway.Message				true	"Send message request"
 //	@Success		202						{object}	smsgateway.GetMessageResponse	"Message enqueued"
 //	@Failure		400						{object}	smsgateway.ErrorResponse		"Invalid request"
@@ -54,7 +54,7 @@ type ThirdPartyController struct {
 //	@Failure		409						{object}	smsgateway.ErrorResponse		"Message with such ID already exists"
 //	@Failure		500						{object}	smsgateway.ErrorResponse		"Internal server error"
 //	@Header			202						{string}	Location						"Get message state URL"
-//	@Router			/3rdparty/v1/messages 																													[post]
+//	@Router			/3rdparty/v1/messages 																																																																	[post]
 //
 // Enqueue message
 func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
@@ -179,7 +179,7 @@ func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
 //	@Failure		400							{object}	smsgateway.ErrorResponse		"Invalid request"
 //	@Failure		401							{object}	smsgateway.ErrorResponse		"Unauthorized"
 //	@Failure		500							{object}	smsgateway.ErrorResponse		"Internal server error"
-//	@Router			/3rdparty/v1/messages/{id} 																												[get]
+//	@Router			/3rdparty/v1/messages/{id} 																																																																[get]
 //
 // Get message state
 func (h *ThirdPartyController) get(user models.User, c *fiber.Ctx) error {
@@ -216,7 +216,7 @@ func (h *ThirdPartyController) get(user models.User, c *fiber.Ctx) error {
 //	@Failure		400							{object}	smsgateway.ErrorResponse			"Invalid request"
 //	@Failure		401							{object}	smsgateway.ErrorResponse			"Unauthorized"
 //	@Failure		500							{object}	smsgateway.ErrorResponse			"Internal server error"
-//	@Router			/3rdparty/v1/inbox/export 																																		[post]
+//	@Router			/3rdparty/v1/inbox/export 																																																																										[post]
 //
 // Export inbox
 func (h *ThirdPartyController) postInboxExport(user models.User, c *fiber.Ctx) error {

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -45,16 +45,16 @@ type ThirdPartyController struct {
 //	@Tags			User, Messages
 //	@Accept			json
 //	@Produce		json
-//	@Param			skipPhoneValidation		query		bool						false	"Skip phone validation"
-//	@Param			deviceActiveWithin		query		int							false	"Filter devices active within the specified number of hours"	default(0)
-//	@Param			request					body		smsgateway.Message			true	"Send message request"
-//	@Success		202						{object}	smsgateway.MessageState		"Message enqueued"
-//	@Failure		400						{object}	smsgateway.ErrorResponse	"Invalid request"
-//	@Failure		401						{object}	smsgateway.ErrorResponse	"Unauthorized"
-//	@Failure		409						{object}	smsgateway.ErrorResponse	"Message with such ID already exists"
-//	@Failure		500						{object}	smsgateway.ErrorResponse	"Internal server error"
-//	@Header			202						{string}	Location					"Get message state URL"
-//	@Router			/3rdparty/v1/messages 																				[post]
+//	@Param			skipPhoneValidation		query		bool							false	"Skip phone validation"
+//	@Param			deviceActiveWithin		query		int								false	"Filter devices active within the specified number of hours"	default(0)
+//	@Param			request					body		smsgateway.Message				true	"Send message request"
+//	@Success		202						{object}	smsgateway.GetMessageResponse	"Message enqueued"
+//	@Failure		400						{object}	smsgateway.ErrorResponse		"Invalid request"
+//	@Failure		401						{object}	smsgateway.ErrorResponse		"Unauthorized"
+//	@Failure		409						{object}	smsgateway.ErrorResponse		"Message with such ID already exists"
+//	@Failure		500						{object}	smsgateway.ErrorResponse		"Internal server error"
+//	@Header			202						{string}	Location						"Get message state URL"
+//	@Router			/3rdparty/v1/messages 																													[post]
 //
 // Enqueue message
 func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
@@ -157,7 +157,16 @@ func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
 		c.Location(location)
 	}
 
-	return c.Status(fiber.StatusAccepted).JSON(state)
+	return c.Status(fiber.StatusAccepted).
+		JSON(smsgateway.GetMessageResponse{
+			ID:          state.ID,
+			DeviceID:    state.DeviceID,
+			State:       smsgateway.ProcessingState(state.State),
+			IsHashed:    state.IsHashed,
+			IsEncrypted: state.IsEncrypted,
+			Recipients:  state.Recipients,
+			States:      state.States,
+		})
 }
 
 //	@Summary		Get message state
@@ -165,12 +174,12 @@ func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
 //	@Security		ApiAuth
 //	@Tags			User, Messages
 //	@Produce		json
-//	@Param			id							path		string						true	"Message ID"
-//	@Success		200							{object}	smsgateway.MessageState		"Message state"
-//	@Failure		400							{object}	smsgateway.ErrorResponse	"Invalid request"
-//	@Failure		401							{object}	smsgateway.ErrorResponse	"Unauthorized"
-//	@Failure		500							{object}	smsgateway.ErrorResponse	"Internal server error"
-//	@Router			/3rdparty/v1/messages/{id} 																			[get]
+//	@Param			id							path		string							true	"Message ID"
+//	@Success		200							{object}	smsgateway.GetMessageResponse	"Message state"
+//	@Failure		400							{object}	smsgateway.ErrorResponse		"Invalid request"
+//	@Failure		401							{object}	smsgateway.ErrorResponse		"Unauthorized"
+//	@Failure		500							{object}	smsgateway.ErrorResponse		"Internal server error"
+//	@Router			/3rdparty/v1/messages/{id} 																												[get]
 //
 // Get message state
 func (h *ThirdPartyController) get(user models.User, c *fiber.Ctx) error {
@@ -185,7 +194,15 @@ func (h *ThirdPartyController) get(user models.User, c *fiber.Ctx) error {
 		return err
 	}
 
-	return c.JSON(state)
+	return c.JSON(smsgateway.GetMessageResponse{
+		ID:          state.ID,
+		DeviceID:    state.DeviceID,
+		State:       smsgateway.ProcessingState(state.State),
+		IsHashed:    state.IsHashed,
+		IsEncrypted: state.IsEncrypted,
+		Recipients:  state.Recipients,
+		States:      state.States,
+	})
 }
 
 //	@Summary		Request inbox messages export
@@ -199,7 +216,7 @@ func (h *ThirdPartyController) get(user models.User, c *fiber.Ctx) error {
 //	@Failure		400							{object}	smsgateway.ErrorResponse			"Invalid request"
 //	@Failure		401							{object}	smsgateway.ErrorResponse			"Unauthorized"
 //	@Failure		500							{object}	smsgateway.ErrorResponse			"Internal server error"
-//	@Router			/3rdparty/v1/inbox/export 																								[post]
+//	@Router			/3rdparty/v1/inbox/export 																																		[post]
 //
 // Export inbox
 func (h *ThirdPartyController) postInboxExport(user models.User, c *fiber.Ctx) error {

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -1,0 +1,6 @@
+package messages
+
+type postQueryParams struct {
+	SkipPhoneValidation bool `query:"skipPhoneValidation"`
+	DeviceActiveWithin  uint `query:"deviceActiveWithin"`
+}

--- a/internal/sms-gateway/handlers/mobile.go
+++ b/internal/sms-gateway/handlers/mobile.go
@@ -195,12 +195,13 @@ func (h *mobileHandler) patchMessage(device models.Device, c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
-	var messageState messages.MessageStateIn
 	for _, v := range req {
-		messageState.ID = v.ID
-		messageState.State = messages.ProcessingState(v.State)
-		messageState.Recipients = v.Recipients
-		messageState.States = v.States
+		messageState := messages.MessageStateIn{
+			ID:         v.ID,
+			State:      messages.ProcessingState(v.State),
+			Recipients: v.Recipients,
+			States:     v.States,
+		}
 
 		err := h.messagesSvc.UpdateState(device.ID, messageState)
 		if err != nil && !errors.Is(err, messages.ErrMessageNotFound) {

--- a/internal/sms-gateway/modules/health/service.go
+++ b/internal/sms-gateway/modules/health/service.go
@@ -49,10 +49,19 @@ func (s *Service) HealthCheck(ctx context.Context) (Check, error) {
 			check.Checks[p.Name()+":"+name] = detail
 
 			switch detail.Status {
+			case StatusPass:
 			case StatusFail:
 				level = max(level, levelFail)
 			case StatusWarn:
 				level = max(level, levelWarn)
+			default:
+				// Unknown status – log it and fail-safe by escalating to `levelFail`.
+				s.logger.Warn("health check returned unknown status",
+					zap.String("provider", p.Name()),
+					zap.String("check", name),
+					zap.String("status", string(detail.Status)),
+				)
+				level = max(level, levelFail)
 			}
 		}
 	}

--- a/internal/sms-gateway/modules/messages/domain.go
+++ b/internal/sms-gateway/modules/messages/domain.go
@@ -27,3 +27,25 @@ type MessageOut struct {
 
 	CreatedAt time.Time
 }
+
+type MessageStateIn struct {
+	// Message ID
+	ID string
+	// State
+	State ProcessingState
+	// Recipients states
+	Recipients []smsgateway.RecipientState
+	// History of states
+	States map[string]time.Time
+}
+
+type MessageStateOut struct {
+	// Device ID
+	DeviceID string
+	// Hashed
+	IsHashed bool
+	// Encrypted
+	IsEncrypted bool
+
+	MessageStateIn
+}

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -2,6 +2,7 @@ package messages
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/android-sms-gateway/server/internal/sms-gateway/models"
@@ -74,7 +75,7 @@ func (m *Message) GetTextContent() (*TextMessageContent, error) {
 
 	err := json.Unmarshal([]byte(m.Content), &content)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal text content: %w", err)
 	}
 
 	return &content, nil
@@ -101,7 +102,7 @@ func (m *Message) GetDataContent() (*DataMessageContent, error) {
 
 	err := json.Unmarshal([]byte(m.Content), &content)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal data content: %w", err)
 	}
 
 	return &content, nil

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -154,7 +154,7 @@ func (s *Service) GetState(user models.User, ID string) (smsgateway.MessageState
 
 func (s *Service) Enqueue(device models.Device, message MessageIn, opts EnqueueOptions) (smsgateway.MessageState, error) {
 	state := smsgateway.MessageState{
-		ID:         "",
+		DeviceID:   device.ID,
 		State:      smsgateway.ProcessingStatePending,
 		Recipients: make([]smsgateway.RecipientState, len(message.PhoneNumbers)),
 	}
@@ -296,6 +296,7 @@ func (s *Service) recipientsStateToModel(input []smsgateway.RecipientState, hash
 func modelToMessageState(input Message) smsgateway.MessageState {
 	return smsgateway.MessageState{
 		ID:          input.ExtID,
+		DeviceID:    input.DeviceID,
 		State:       smsgateway.ProcessingState(input.State),
 		IsHashed:    input.IsHashed,
 		IsEncrypted: input.IsEncrypted,

--- a/pkg/swagger/docs/mobile.http
+++ b/pkg/swagger/docs/mobile.http
@@ -43,7 +43,7 @@ Content-Type: application/json
 
 [
   {
-    "id": "2dcIAhcLg81cez7GE_Pdp",
+    "id": "NBjsgnVp72pvcdonJm7a5",
     "state": "Failed",
     "recipients": [
       {

--- a/pkg/swagger/docs/requests.http
+++ b/pkg/swagger/docs/requests.http
@@ -10,7 +10,7 @@ GET {{baseUrl}}/health HTTP/1.1
 GET {{baseUrl}}/3rdparty/v1/health HTTP/1.1
 
 ###
-POST {{baseUrl}}/3rdparty/v1/messages?skipPhoneValidation=false HTTP/1.1
+POST {{baseUrl}}/3rdparty/v1/messages?skipPhoneValidation=false&deviceActiveWithin=240 HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{credentials}}
 

--- a/pkg/swagger/docs/swagger.json
+++ b/pkg/swagger/docs/swagger.json
@@ -311,7 +311,7 @@
                     "202": {
                         "description": "Message enqueued",
                         "schema": {
-                            "$ref": "#/definitions/smsgateway.MessageState"
+                            "$ref": "#/definitions/smsgateway.GetMessageResponse"
                         },
                         "headers": {
                             "Location": {
@@ -376,7 +376,7 @@
                     "200": {
                         "description": "Message state",
                         "schema": {
-                            "$ref": "#/definitions/smsgateway.MessageState"
+                            "$ref": "#/definitions/smsgateway.GetMessageResponse"
                         }
                     },
                     "400": {
@@ -900,7 +900,43 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/smsgateway.MessageState"
+                                "type": "object",
+                                "required": [
+                                    "recipients",
+                                    "state"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "description": "Message ID",
+                                        "type": "string",
+                                        "maxLength": 36,
+                                        "example": "PyDmBQZZXYmyxMwED8Fzy"
+                                    },
+                                    "recipients": {
+                                        "description": "Recipients states",
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "items": {
+                                            "$ref": "#/definitions/smsgateway.RecipientState"
+                                        }
+                                    },
+                                    "state": {
+                                        "description": "State",
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/definitions/smsgateway.ProcessingState"
+                                            }
+                                        ],
+                                        "example": "Pending"
+                                    },
+                                    "states": {
+                                        "description": "History of states",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -1266,6 +1302,62 @@
                 }
             }
         },
+        "smsgateway.GetMessageResponse": {
+            "type": "object",
+            "required": [
+                "deviceId",
+                "recipients",
+                "state"
+            ],
+            "properties": {
+                "deviceId": {
+                    "description": "Device ID",
+                    "type": "string",
+                    "maxLength": 21,
+                    "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
+                "id": {
+                    "description": "Message ID",
+                    "type": "string",
+                    "maxLength": 36,
+                    "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
+                "isEncrypted": {
+                    "description": "Encrypted",
+                    "type": "boolean",
+                    "example": false
+                },
+                "isHashed": {
+                    "description": "Hashed",
+                    "type": "boolean",
+                    "example": false
+                },
+                "recipients": {
+                    "description": "Recipients states",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/smsgateway.RecipientState"
+                    }
+                },
+                "state": {
+                    "description": "State",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.ProcessingState"
+                        }
+                    ],
+                    "example": "Pending"
+                },
+                "states": {
+                    "description": "History of states",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "smsgateway.HealthCheck": {
             "type": "object",
             "properties": {
@@ -1515,62 +1607,6 @@
                 "PriorityBypassThreshold",
                 "PriorityMaximum"
             ]
-        },
-        "smsgateway.MessageState": {
-            "type": "object",
-            "required": [
-                "deviceId",
-                "recipients",
-                "state"
-            ],
-            "properties": {
-                "deviceId": {
-                    "description": "Device ID",
-                    "type": "string",
-                    "maxLength": 21,
-                    "example": "PyDmBQZZXYmyxMwED8Fzy"
-                },
-                "id": {
-                    "description": "Message ID",
-                    "type": "string",
-                    "maxLength": 36,
-                    "example": "PyDmBQZZXYmyxMwED8Fzy"
-                },
-                "isEncrypted": {
-                    "description": "Encrypted",
-                    "type": "boolean",
-                    "example": false
-                },
-                "isHashed": {
-                    "description": "Hashed",
-                    "type": "boolean",
-                    "example": false
-                },
-                "recipients": {
-                    "description": "Recipients states",
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                        "$ref": "#/definitions/smsgateway.RecipientState"
-                    }
-                },
-                "state": {
-                    "description": "State",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/smsgateway.ProcessingState"
-                        }
-                    ],
-                    "example": "Pending"
-                },
-                "states": {
-                    "description": "History of states",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
         },
         "smsgateway.MessagesExportRequest": {
             "type": "object",

--- a/pkg/swagger/docs/swagger.json
+++ b/pkg/swagger/docs/swagger.json
@@ -1412,6 +1412,12 @@
                         }
                     ]
                 },
+                "deviceId": {
+                    "description": "Optional device ID for explicit selection",
+                    "type": "string",
+                    "maxLength": 21,
+                    "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
                 "id": {
                     "description": "ID (if not set - will be generated)",
                     "type": "string",
@@ -1506,10 +1512,17 @@
         "smsgateway.MessageState": {
             "type": "object",
             "required": [
+                "deviceId",
                 "recipients",
                 "state"
             ],
             "properties": {
+                "deviceId": {
+                    "description": "Device ID",
+                    "type": "string",
+                    "maxLength": 21,
+                    "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
                 "id": {
                     "description": "Message ID",
                     "type": "string",
@@ -1633,6 +1646,12 @@
                             "$ref": "#/definitions/smsgateway.DataMessage"
                         }
                     ]
+                },
+                "deviceId": {
+                    "description": "Optional device ID for explicit selection",
+                    "type": "string",
+                    "maxLength": 21,
+                    "example": "PyDmBQZZXYmyxMwED8Fzy"
                 },
                 "id": {
                     "description": "ID (if not set - will be generated)",

--- a/pkg/swagger/docs/swagger.json
+++ b/pkg/swagger/docs/swagger.json
@@ -291,6 +291,13 @@
                         "in": "query"
                     },
                     {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Filter devices active within the specified number of hours",
+                        "name": "deviceActiveWithin",
+                        "in": "query"
+                    },
+                    {
                         "description": "Send message request",
                         "name": "request",
                         "in": "body",

--- a/pkg/swagger/docs/swagger.json
+++ b/pkg/swagger/docs/swagger.json
@@ -271,7 +271,7 @@
                         "ApiAuth": []
                     }
                 ],
-                "description": "Enqueues message for sending. If multiple devices are registered, it will be sent via a random one",
+                "description": "Enqueues a message for sending. If `deviceId` is set, the specified device is used; otherwise a random registered device is chosen.",
                 "consumes": [
                     "application/json"
                 ],
@@ -291,6 +291,7 @@
                         "in": "query"
                     },
                     {
+                        "minimum": 0,
                         "type": "integer",
                         "default": 0,
                         "description": "Filter devices active within the specified number of hours",

--- a/pkg/swagger/docs/swagger.yaml
+++ b/pkg/swagger/docs/swagger.yaml
@@ -80,6 +80,47 @@ definitions:
         example: An error occurred
         type: string
     type: object
+  smsgateway.GetMessageResponse:
+    properties:
+      deviceId:
+        description: Device ID
+        example: PyDmBQZZXYmyxMwED8Fzy
+        maxLength: 21
+        type: string
+      id:
+        description: Message ID
+        example: PyDmBQZZXYmyxMwED8Fzy
+        maxLength: 36
+        type: string
+      isEncrypted:
+        description: Encrypted
+        example: false
+        type: boolean
+      isHashed:
+        description: Hashed
+        example: false
+        type: boolean
+      recipients:
+        description: Recipients states
+        items:
+          $ref: '#/definitions/smsgateway.RecipientState'
+        minItems: 1
+        type: array
+      state:
+        allOf:
+        - $ref: '#/definitions/smsgateway.ProcessingState'
+        description: State
+        example: Pending
+      states:
+        additionalProperties:
+          type: string
+        description: History of states
+        type: object
+    required:
+    - deviceId
+    - recipients
+    - state
+    type: object
   smsgateway.HealthCheck:
     properties:
       description:
@@ -267,47 +308,6 @@ definitions:
     - PriorityDefault
     - PriorityBypassThreshold
     - PriorityMaximum
-  smsgateway.MessageState:
-    properties:
-      deviceId:
-        description: Device ID
-        example: PyDmBQZZXYmyxMwED8Fzy
-        maxLength: 21
-        type: string
-      id:
-        description: Message ID
-        example: PyDmBQZZXYmyxMwED8Fzy
-        maxLength: 36
-        type: string
-      isEncrypted:
-        description: Encrypted
-        example: false
-        type: boolean
-      isHashed:
-        description: Hashed
-        example: false
-        type: boolean
-      recipients:
-        description: Recipients states
-        items:
-          $ref: '#/definitions/smsgateway.RecipientState'
-        minItems: 1
-        type: array
-      state:
-        allOf:
-        - $ref: '#/definitions/smsgateway.ProcessingState'
-        description: State
-        example: Pending
-      states:
-        additionalProperties:
-          type: string
-        description: History of states
-        type: object
-    required:
-    - deviceId
-    - recipients
-    - state
-    type: object
   smsgateway.MessagesExportRequest:
     properties:
       deviceId:
@@ -921,7 +921,7 @@ paths:
               description: Get message state URL
               type: string
           schema:
-            $ref: '#/definitions/smsgateway.MessageState'
+            $ref: '#/definitions/smsgateway.GetMessageResponse'
         "400":
           description: Invalid request
           schema:
@@ -959,7 +959,7 @@ paths:
         "200":
           description: Message state
           schema:
-            $ref: '#/definitions/smsgateway.MessageState'
+            $ref: '#/definitions/smsgateway.GetMessageResponse'
         "400":
           description: Invalid request
           schema:
@@ -1292,7 +1292,32 @@ paths:
         required: true
         schema:
           items:
-            $ref: '#/definitions/smsgateway.MessageState'
+            properties:
+              id:
+                description: Message ID
+                example: PyDmBQZZXYmyxMwED8Fzy
+                maxLength: 36
+                type: string
+              recipients:
+                description: Recipients states
+                items:
+                  $ref: '#/definitions/smsgateway.RecipientState'
+                minItems: 1
+                type: array
+              state:
+                allOf:
+                - $ref: '#/definitions/smsgateway.ProcessingState'
+                description: State
+                example: Pending
+              states:
+                additionalProperties:
+                  type: string
+                description: History of states
+                type: object
+            required:
+            - recipients
+            - state
+            type: object
           type: array
       produces:
       - application/json

--- a/pkg/swagger/docs/swagger.yaml
+++ b/pkg/swagger/docs/swagger.yaml
@@ -15,8 +15,8 @@ definitions:
         minimum: 1
         type: integer
     required:
-      - data
-      - port
+    - data
+    - port
     type: object
   smsgateway.Device:
     properties:
@@ -49,23 +49,23 @@ definitions:
     properties:
       encryption:
         allOf:
-          - $ref: "#/definitions/smsgateway.SettingsEncryption"
+        - $ref: '#/definitions/smsgateway.SettingsEncryption'
         description: Encryption contains settings related to message encryption.
       logs:
         allOf:
-          - $ref: "#/definitions/smsgateway.SettingsLogs"
+        - $ref: '#/definitions/smsgateway.SettingsLogs'
         description: Logs contains settings related to logging.
       messages:
         allOf:
-          - $ref: "#/definitions/smsgateway.SettingsMessages"
+        - $ref: '#/definitions/smsgateway.SettingsMessages'
         description: Messages contains settings related to message handling.
       ping:
         allOf:
-          - $ref: "#/definitions/smsgateway.SettingsPing"
+        - $ref: '#/definitions/smsgateway.SettingsPing'
         description: Ping contains settings related to ping functionality.
       webhooks:
         allOf:
-          - $ref: "#/definitions/smsgateway.SettingsWebhooks"
+        - $ref: '#/definitions/smsgateway.SettingsWebhooks'
         description: Webhooks contains settings related to webhook functionality.
     type: object
   smsgateway.ErrorResponse:
@@ -93,20 +93,20 @@ definitions:
         type: integer
       status:
         allOf:
-          - $ref: "#/definitions/smsgateway.HealthStatus"
+        - $ref: '#/definitions/smsgateway.HealthStatus'
         description: |-
           Status of the check.
           It can be one of the following values: "pass", "warn", or "fail".
     type: object
   smsgateway.HealthChecks:
     additionalProperties:
-      $ref: "#/definitions/smsgateway.HealthCheck"
+      $ref: '#/definitions/smsgateway.HealthCheck'
     type: object
   smsgateway.HealthResponse:
     properties:
       checks:
         allOf:
-          - $ref: "#/definitions/smsgateway.HealthChecks"
+        - $ref: '#/definitions/smsgateway.HealthChecks'
         description: A map of check names to their respective details.
       releaseId:
         description: |-
@@ -115,7 +115,7 @@ definitions:
         type: integer
       status:
         allOf:
-          - $ref: "#/definitions/smsgateway.HealthStatus"
+        - $ref: '#/definitions/smsgateway.HealthStatus'
         description: |-
           Overall status of the application.
           It can be one of the following values: "pass", "warn", or "fail".
@@ -125,33 +125,32 @@ definitions:
     type: object
   smsgateway.HealthStatus:
     enum:
-      - pass
-      - warn
-      - fail
+    - pass
+    - warn
+    - fail
     type: string
     x-enum-varnames:
-      - HealthStatusPass
-      - HealthStatusWarn
-      - HealthStatusFail
+    - HealthStatusPass
+    - HealthStatusWarn
+    - HealthStatusFail
   smsgateway.LimitPeriod:
     enum:
-      - Disabled
-      - PerMinute
-      - PerHour
-      - PerDay
+    - Disabled
+    - PerMinute
+    - PerHour
+    - PerDay
     type: string
     x-enum-varnames:
-      - Disabled
-      - PerMinute
-      - PerHour
-      - PerDay
+    - Disabled
+    - PerMinute
+    - PerHour
+    - PerDay
   smsgateway.LogEntry:
     properties:
       context:
         additionalProperties:
           type: string
-        description:
-          Additional context information related to the log entry, typically
+        description: Additional context information related to the log entry, typically
           including data relevant to the log event.
         type: object
       createdAt:
@@ -164,33 +163,37 @@ definitions:
         description: A message describing the log event.
         type: string
       module:
-        description:
-          The module or component of the system that generated the log
+        description: The module or component of the system that generated the log
           entry.
         type: string
       priority:
         allOf:
-          - $ref: "#/definitions/smsgateway.LogEntryPriority"
+        - $ref: '#/definitions/smsgateway.LogEntryPriority'
         description: The priority level of the log entry.
     type: object
   smsgateway.LogEntryPriority:
     enum:
-      - DEBUG
-      - INFO
-      - WARN
-      - ERROR
+    - DEBUG
+    - INFO
+    - WARN
+    - ERROR
     type: string
     x-enum-varnames:
-      - LogEntryPriorityDebug
-      - LogEntryPriorityInfo
-      - LogEntryPriorityWarn
-      - LogEntryPriorityError
+    - LogEntryPriorityDebug
+    - LogEntryPriorityInfo
+    - LogEntryPriorityWarn
+    - LogEntryPriorityError
   smsgateway.Message:
     properties:
       dataMessage:
         allOf:
-          - $ref: "#/definitions/smsgateway.DataMessage"
+        - $ref: '#/definitions/smsgateway.DataMessage'
         description: Data message
+      deviceId:
+        description: Optional device ID for explicit selection
+        example: PyDmBQZZXYmyxMwED8Fzy
+        maxLength: 21
+        type: string
       id:
         description: ID (if not set - will be generated)
         example: PyDmBQZZXYmyxMwED8Fzy
@@ -210,7 +213,7 @@ definitions:
       phoneNumbers:
         description: Recipients (phone numbers)
         example:
-          - "79990001234"
+        - "79990001234"
         items:
           type: string
         maxItems: 100
@@ -218,10 +221,9 @@ definitions:
         type: array
       priority:
         allOf:
-          - $ref: "#/definitions/smsgateway.MessagePriority"
+        - $ref: '#/definitions/smsgateway.MessagePriority'
         default: 0
-        description:
-          Priority, messages with values greater than `99` will bypass
+        description: Priority, messages with values greater than `99` will bypass
           limits and delays
         example: 0
         maximum: 127
@@ -233,7 +235,7 @@ definitions:
         type: integer
       textMessage:
         allOf:
-          - $ref: "#/definitions/smsgateway.TextMessage"
+        - $ref: '#/definitions/smsgateway.TextMessage'
         description: Text message
       ttl:
         description: Time to live in seconds (conflicts with `validUntil`)
@@ -249,24 +251,29 @@ definitions:
         example: true
         type: boolean
     required:
-      - phoneNumbers
+    - phoneNumbers
     type: object
   smsgateway.MessagePriority:
     enum:
-      - -128
-      - 0
-      - 100
-      - 127
+    - -128
+    - 0
+    - 100
+    - 127
     type: integer
     x-enum-comments:
       PriorityBypassThreshold: Threshold at which messages bypass limits and delays
     x-enum-varnames:
-      - PriorityMinimum
-      - PriorityDefault
-      - PriorityBypassThreshold
-      - PriorityMaximum
+    - PriorityMinimum
+    - PriorityDefault
+    - PriorityBypassThreshold
+    - PriorityMaximum
   smsgateway.MessageState:
     properties:
+      deviceId:
+        description: Device ID
+        example: PyDmBQZZXYmyxMwED8Fzy
+        maxLength: 21
+        type: string
       id:
         description: Message ID
         example: PyDmBQZZXYmyxMwED8Fzy
@@ -283,12 +290,12 @@ definitions:
       recipients:
         description: Recipients states
         items:
-          $ref: "#/definitions/smsgateway.RecipientState"
+          $ref: '#/definitions/smsgateway.RecipientState'
         minItems: 1
         type: array
       state:
         allOf:
-          - $ref: "#/definitions/smsgateway.ProcessingState"
+        - $ref: '#/definitions/smsgateway.ProcessingState'
         description: State
         example: Pending
       states:
@@ -297,8 +304,9 @@ definitions:
         description: History of states
         type: object
     required:
-      - recipients
-      - state
+    - deviceId
+    - recipients
+    - state
     type: object
   smsgateway.MessagesExportRequest:
     properties:
@@ -316,9 +324,9 @@ definitions:
         example: "2024-01-01T23:59:59Z"
         type: string
     required:
-      - deviceId
-      - since
-      - until
+    - deviceId
+    - since
+    - until
     type: object
   smsgateway.MobileChangePasswordRequest:
     properties:
@@ -332,16 +340,15 @@ definitions:
         minLength: 14
         type: string
     required:
-      - currentPassword
-      - newPassword
+    - currentPassword
+    - newPassword
     type: object
   smsgateway.MobileDeviceResponse:
     properties:
       device:
         allOf:
-          - $ref: "#/definitions/smsgateway.Device"
-        description:
-          Device information, empty if device is not registered on the
+        - $ref: '#/definitions/smsgateway.Device'
+        description: Device information, empty if device is not registered on the
           server
       externalIp:
         description: External IP
@@ -355,8 +362,13 @@ definitions:
         type: string
       dataMessage:
         allOf:
-          - $ref: "#/definitions/smsgateway.DataMessage"
+        - $ref: '#/definitions/smsgateway.DataMessage'
         description: Data message
+      deviceId:
+        description: Optional device ID for explicit selection
+        example: PyDmBQZZXYmyxMwED8Fzy
+        maxLength: 21
+        type: string
       id:
         description: ID (if not set - will be generated)
         example: PyDmBQZZXYmyxMwED8Fzy
@@ -376,7 +388,7 @@ definitions:
       phoneNumbers:
         description: Recipients (phone numbers)
         example:
-          - "79990001234"
+        - "79990001234"
         items:
           type: string
         maxItems: 100
@@ -384,10 +396,9 @@ definitions:
         type: array
       priority:
         allOf:
-          - $ref: "#/definitions/smsgateway.MessagePriority"
+        - $ref: '#/definitions/smsgateway.MessagePriority'
         default: 0
-        description:
-          Priority, messages with values greater than `99` will bypass
+        description: Priority, messages with values greater than `99` will bypass
           limits and delays
         example: 0
         maximum: 127
@@ -399,7 +410,7 @@ definitions:
         type: integer
       textMessage:
         allOf:
-          - $ref: "#/definitions/smsgateway.TextMessage"
+        - $ref: '#/definitions/smsgateway.TextMessage'
         description: Text message
       ttl:
         description: Time to live in seconds (conflicts with `validUntil`)
@@ -415,7 +426,7 @@ definitions:
         example: true
         type: boolean
     required:
-      - phoneNumbers
+    - phoneNumbers
     type: object
   smsgateway.MobileRegisterRequest:
     properties:
@@ -474,11 +485,11 @@ definitions:
     type: object
   smsgateway.ProcessingState:
     enum:
-      - Pending
-      - Processed
-      - Sent
-      - Delivered
-      - Failed
+    - Pending
+    - Processed
+    - Sent
+    - Delivered
+    - Failed
     type: string
     x-enum-comments:
       ProcessingStateDelivered: Delivered
@@ -487,23 +498,23 @@ definitions:
       ProcessingStateProcessed: Processed (received by device)
       ProcessingStateSent: Sent
     x-enum-varnames:
-      - ProcessingStatePending
-      - ProcessingStateProcessed
-      - ProcessingStateSent
-      - ProcessingStateDelivered
-      - ProcessingStateFailed
+    - ProcessingStatePending
+    - ProcessingStateProcessed
+    - ProcessingStateSent
+    - ProcessingStateDelivered
+    - ProcessingStateFailed
   smsgateway.PushEventType:
     enum:
-      - MessageEnqueued
-      - WebhooksUpdated
-      - MessagesExportRequested
-      - SettingsUpdated
+    - MessageEnqueued
+    - WebhooksUpdated
+    - MessagesExportRequested
+    - SettingsUpdated
     type: string
     x-enum-varnames:
-      - PushMessageEnqueued
-      - PushWebhooksUpdated
-      - PushMessagesExportRequested
-      - PushSettingsUpdated
+    - PushMessageEnqueued
+    - PushWebhooksUpdated
+    - PushMessagesExportRequested
+    - PushSettingsUpdated
   smsgateway.PushNotification:
     properties:
       data:
@@ -513,21 +524,21 @@ definitions:
         type: object
       event:
         allOf:
-          - $ref: "#/definitions/smsgateway.PushEventType"
+        - $ref: '#/definitions/smsgateway.PushEventType'
         default: MessageEnqueued
         description: The type of event.
         enum:
-          - MessageEnqueued
-          - WebhooksUpdated
-          - MessagesExportRequested
-          - SettingsUpdated
+        - MessageEnqueued
+        - WebhooksUpdated
+        - MessagesExportRequested
+        - SettingsUpdated
         example: MessageEnqueued
       token:
         description: The token of the device that receives the notification.
         example: PyDmBQZZXYmyxMwED8Fzy
         type: string
     required:
-      - token
+    - token
     type: object
   smsgateway.RecipientState:
     properties:
@@ -543,18 +554,17 @@ definitions:
         type: string
       state:
         allOf:
-          - $ref: "#/definitions/smsgateway.ProcessingState"
+        - $ref: '#/definitions/smsgateway.ProcessingState'
         description: State
         example: Pending
     required:
-      - phoneNumber
-      - state
+    - phoneNumber
+    - state
     type: object
   smsgateway.SettingsEncryption:
     properties:
       passphrase:
-        description:
-          Passphrase is the encryption passphrase. If nil or empty, encryption
+        description: Passphrase is the encryption passphrase. If nil or empty, encryption
           is disabled.
         type: string
     type: object
@@ -571,15 +581,15 @@ definitions:
     properties:
       limit_period:
         allOf:
-          - $ref: "#/definitions/smsgateway.LimitPeriod"
+        - $ref: '#/definitions/smsgateway.LimitPeriod'
         description: |-
           LimitPeriod defines the period for message sending limits.
           Valid values are "Disabled", "PerMinute", "PerHour", or "PerDay".
         enum:
-          - Disabled
-          - PerMinute
-          - PerHour
-          - PerDay
+        - Disabled
+        - PerMinute
+        - PerHour
+        - PerDay
       limit_value:
         description: |-
           LimitValue is the maximum number of messages allowed per limit period.
@@ -606,14 +616,14 @@ definitions:
         type: integer
       sim_selection_mode:
         allOf:
-          - $ref: "#/definitions/smsgateway.SimSelectionMode"
+        - $ref: '#/definitions/smsgateway.SimSelectionMode'
         description: |-
           SimSelectionMode defines how SIM cards are selected for sending messages.
           Valid values are "OSDefault", "RoundRobin", or "Random".
         enum:
-          - OSDefault
-          - RoundRobin
-          - Random
+        - OSDefault
+        - RoundRobin
+        - Random
     type: object
   smsgateway.SettingsPing:
     properties:
@@ -627,8 +637,7 @@ definitions:
   smsgateway.SettingsWebhooks:
     properties:
       internet_required:
-        description:
-          InternetRequired indicates whether internet access is required
+        description: InternetRequired indicates whether internet access is required
           for webhooks.
         type: boolean
       retry_count:
@@ -643,14 +652,14 @@ definitions:
     type: object
   smsgateway.SimSelectionMode:
     enum:
-      - OSDefault
-      - RoundRobin
-      - Random
+    - OSDefault
+    - RoundRobin
+    - Random
     type: string
     x-enum-varnames:
-      - OSDefault
-      - RoundRobin
-      - Random
+    - OSDefault
+    - RoundRobin
+    - Random
   smsgateway.TextMessage:
     properties:
       text:
@@ -660,20 +669,19 @@ definitions:
         minLength: 1
         type: string
     required:
-      - text
+    - text
     type: object
   smsgateway.Webhook:
     properties:
       deviceId:
-        description:
-          The unique identifier of the device the webhook is associated
+        description: The unique identifier of the device the webhook is associated
           with.
         example: PyDmBQZZXYmyxMwED8Fzy
         maxLength: 21
         type: string
       event:
         allOf:
-          - $ref: "#/definitions/smsgateway.WebhookEvent"
+        - $ref: '#/definitions/smsgateway.WebhookEvent'
         description: The type of event the webhook is triggered for.
         example: sms:received
       id:
@@ -686,137 +694,135 @@ definitions:
         example: https://example.com/webhook
         type: string
     required:
-      - event
-      - url
+    - event
+    - url
     type: object
   smsgateway.WebhookEvent:
     enum:
-      - sms:received
-      - sms:data-received
-      - sms:sent
-      - sms:delivered
-      - sms:failed
-      - system:ping
+    - sms:received
+    - sms:data-received
+    - sms:sent
+    - sms:delivered
+    - sms:failed
+    - system:ping
     type: string
     x-enum-varnames:
-      - WebhookEventSmsReceived
-      - WebhookEventSmsDataReceived
-      - WebhookEventSmsSent
-      - WebhookEventSmsDelivered
-      - WebhookEventSmsFailed
-      - WebhookEventSystemPing
+    - WebhookEventSmsReceived
+    - WebhookEventSmsDataReceived
+    - WebhookEventSmsSent
+    - WebhookEventSmsDelivered
+    - WebhookEventSmsFailed
+    - WebhookEventSystemPing
 host: api.sms-gate.app
 info:
   contact:
     email: support@sms-gate.app
     name: SMSGate Support
-  description:
-    This API provides programmatic access to sending SMS messages on Android
+  description: This API provides programmatic access to sending SMS messages on Android
     devices. Features include sending SMS, checking message status, device management,
     webhook configuration, and system health checks.
   title: SMS Gateway for Android™ API
-  version: "{APP_VERSION}"
+  version: '{APP_VERSION}'
 paths:
   /3rdparty/v1/devices:
     get:
       description: Returns list of registered devices
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Device list
           schema:
             items:
-              $ref: "#/definitions/smsgateway.Device"
+              $ref: '#/definitions/smsgateway.Device'
             type: array
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: List devices
       tags:
-        - User
-        - Devices
+      - User
+      - Devices
   /3rdparty/v1/devices/{id}:
     delete:
       description: Removes device
       parameters:
-        - description: Device ID
-          in: path
-          name: id
-          required: true
-          type: string
+      - description: Device ID
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
-        - application/json
+      - application/json
       responses:
         "204":
           description: Successfully removed
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "404":
           description: Device not found
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Remove device
       tags:
-        - User
-        - Devices
+      - User
+      - Devices
   /3rdparty/v1/health:
     get:
       description: Checks if service is healthy
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Health check result
           schema:
-            $ref: "#/definitions/smsgateway.HealthResponse"
+            $ref: '#/definitions/smsgateway.HealthResponse'
         "500":
           description: Service is unhealthy
           schema:
-            $ref: "#/definitions/smsgateway.HealthResponse"
+            $ref: '#/definitions/smsgateway.HealthResponse'
       summary: Health check
       tags:
-        - System
+      - System
   /3rdparty/v1/inbox/export:
     post:
       consumes:
-        - application/json
-      description:
-        Initiates process of inbox messages export via webhooks. For each
+      - application/json
+      description: Initiates process of inbox messages export via webhooks. For each
         message the `sms:received` webhook will be triggered. The webhooks will be
         triggered without specific order.
       parameters:
-        - description: Export inbox request
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.MessagesExportRequest"
+      - description: Export inbox request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.MessagesExportRequest'
       produces:
-        - application/json
+      - application/json
       responses:
         "202":
           description: Inbox export request accepted
@@ -825,86 +831,83 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Request inbox messages export
       tags:
-        - User
-        - Messages
+      - User
+      - Messages
   /3rdparty/v1/logs:
     get:
       description: Retrieve a list of log entries within a specified time range.
       parameters:
-        - description:
-            The start of the time range for the logs to retrieve. Logs created
-            after this timestamp will be included.
-          format: date-time
-          in: query
-          name: from
-          type: string
-        - description:
-            The end of the time range for the logs to retrieve. Logs created
-            before this timestamp will be included.
-          format: date-time
-          in: query
-          name: to
-          type: string
+      - description: The start of the time range for the logs to retrieve. Logs created
+          after this timestamp will be included.
+        format: date-time
+        in: query
+        name: from
+        type: string
+      - description: The end of the time range for the logs to retrieve. Logs created
+          before this timestamp will be included.
+        format: date-time
+        in: query
+        name: to
+        type: string
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Log entries
           schema:
             items:
-              $ref: "#/definitions/smsgateway.LogEntry"
+              $ref: '#/definitions/smsgateway.LogEntry'
             type: array
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "501":
           description: Not implemented
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Get logs
       tags:
-        - System
-        - Logs
+      - System
+      - Logs
   /3rdparty/v1/messages:
     post:
       consumes:
-        - application/json
-      description:
-        Enqueues message for sending. If multiple devices are registered,
+      - application/json
+      description: Enqueues message for sending. If multiple devices are registered,
         it will be sent via a random one
       parameters:
-        - description: Skip phone validation
-          in: query
-          name: skipPhoneValidation
-          type: boolean
-        - description: Send message request
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.Message"
+      - description: Skip phone validation
+        in: query
+        name: skipPhoneValidation
+        type: boolean
+      - description: Send message request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.Message'
       produces:
-        - application/json
+      - application/json
       responses:
         "202":
           description: Message enqueued
@@ -913,100 +916,100 @@ paths:
               description: Get message state URL
               type: string
           schema:
-            $ref: "#/definitions/smsgateway.MessageState"
+            $ref: '#/definitions/smsgateway.MessageState'
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "409":
           description: Message with such ID already exists
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Enqueue message
       tags:
-        - User
-        - Messages
+      - User
+      - Messages
   /3rdparty/v1/messages/{id}:
     get:
       description: Returns message state by ID
       parameters:
-        - description: Message ID
-          in: path
-          name: id
-          required: true
-          type: string
+      - description: Message ID
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Message state
           schema:
-            $ref: "#/definitions/smsgateway.MessageState"
+            $ref: '#/definitions/smsgateway.MessageState'
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Get message state
       tags:
-        - User
-        - Messages
+      - User
+      - Messages
   /3rdparty/v1/settings:
     get:
       description: Returns settings for a specific user
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Settings
           schema:
-            $ref: "#/definitions/smsgateway.DeviceSettings"
+            $ref: '#/definitions/smsgateway.DeviceSettings'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Get settings
       tags:
-        - User
-        - Settings
+      - User
+      - Settings
     patch:
       consumes:
-        - application/json
+      - application/json
       description: Partially updates settings for a specific user
       parameters:
-        - description: Settings
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.DeviceSettings"
+      - description: Settings
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.DeviceSettings'
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Settings updated
@@ -1015,34 +1018,34 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Partially update settings
       tags:
-        - User
-        - Settings
+      - User
+      - Settings
     put:
       consumes:
-        - application/json
+      - application/json
       description: Replaces settings
       parameters:
-        - description: Settings
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.DeviceSettings"
+      - description: Settings
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.DeviceSettings'
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Settings updated
@@ -1051,96 +1054,95 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Replace settings
       tags:
-        - User
-        - Settings
+      - User
+      - Settings
   /3rdparty/v1/webhooks:
     get:
       description: Returns list of registered webhooks
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Webhook list
           schema:
             items:
-              $ref: "#/definitions/smsgateway.Webhook"
+              $ref: '#/definitions/smsgateway.Webhook'
             type: array
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: List webhooks
       tags:
-        - User
-        - Webhooks
+      - User
+      - Webhooks
     post:
       consumes:
-        - application/json
-      description:
-        Registers webhook. If webhook with same ID already exists, it will
+      - application/json
+      description: Registers webhook. If webhook with same ID already exists, it will
         be replaced
       parameters:
-        - description: Webhook
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.Webhook"
+      - description: Webhook
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.Webhook'
       produces:
-        - application/json
+      - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: "#/definitions/smsgateway.Webhook"
+            $ref: '#/definitions/smsgateway.Webhook'
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Register webhook
       tags:
-        - User
-        - Webhooks
+      - User
+      - Webhooks
   /3rdparty/v1/webhooks/{id}:
     delete:
       description: Deletes webhook
       parameters:
-        - description: Webhook ID
-          in: path
-          name: id
-          required: true
-          type: string
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
       produces:
-        - application/json
+      - application/json
       responses:
         "204":
           description: Webhook deleted
@@ -1149,305 +1151,304 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Delete webhook
       tags:
-        - User
-        - Webhooks
+      - User
+      - Webhooks
   /mobile/v1/device:
     get:
       description: Returns device information
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Device information
           schema:
-            $ref: "#/definitions/smsgateway.MobileDeviceResponse"
+            $ref: '#/definitions/smsgateway.MobileDeviceResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       summary: Get device information
       tags:
-        - Device
+      - Device
     patch:
       consumes:
-        - application/json
+      - application/json
       description: Updates push token for device
       parameters:
-        - description: Device update request
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.MobileUpdateRequest"
+      - description: Device update request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.MobileUpdateRequest'
       responses:
         "204":
           description: Successfully updated
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "403":
           description: Forbidden (wrong device ID)
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - MobileToken: []
+      - MobileToken: []
       summary: Update device
       tags:
-        - Device
+      - Device
     post:
       consumes:
-        - application/json
-      description:
-        Registers new device for new or existing user. Returns user credentials
+      - application/json
+      description: Registers new device for new or existing user. Returns user credentials
         only for new users
       parameters:
-        - description: Device registration request
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.MobileRegisterRequest"
+      - description: Device registration request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.MobileRegisterRequest'
       produces:
-        - application/json
+      - application/json
       responses:
         "201":
           description: Device registered
           schema:
-            $ref: "#/definitions/smsgateway.MobileRegisterResponse"
+            $ref: '#/definitions/smsgateway.MobileRegisterResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized (private mode only)
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "429":
           description: Too many requests
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
-        - UserCode: []
-        - ServerKey: []
+      - ApiAuth: []
+      - UserCode: []
+      - ServerKey: []
       summary: Register device
       tags:
-        - Device
+      - Device
   /mobile/v1/message:
     get:
       consumes:
-        - application/json
+      - application/json
       description: Returns list of pending messages
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: List of pending messages
           schema:
             items:
-              $ref: "#/definitions/smsgateway.MobileMessage"
+              $ref: '#/definitions/smsgateway.MobileMessage'
             type: array
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - MobileToken: []
+      - MobileToken: []
       summary: Get messages for sending
       tags:
-        - Device
-        - Messages
+      - Device
+      - Messages
     patch:
       consumes:
-        - application/json
+      - application/json
       description: Updates message state
       parameters:
-        - description: New message state
-          in: body
-          name: request
-          required: true
-          schema:
-            items:
-              $ref: "#/definitions/smsgateway.MessageState"
-            type: array
+      - description: New message state
+        in: body
+        name: request
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/smsgateway.MessageState'
+          type: array
       produces:
-        - application/json
+      - application/json
       responses:
         "204":
           description: Successfully updated
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - MobileToken: []
+      - MobileToken: []
       summary: Update message state
       tags:
-        - Device
-        - Messages
+      - Device
+      - Messages
   /mobile/v1/settings:
     get:
       description: Returns settings for a device
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Settings
           schema:
-            $ref: "#/definitions/smsgateway.DeviceSettings"
+            $ref: '#/definitions/smsgateway.DeviceSettings'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - MobileToken: []
+      - MobileToken: []
       summary: Get settings
       tags:
-        - Device
-        - Settings
+      - Device
+      - Settings
   /mobile/v1/user/code:
     get:
       consumes:
-        - application/json
+      - application/json
       description: Returns one-time code for device registration
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: User code
           schema:
-            $ref: "#/definitions/smsgateway.MobileUserCodeResponse"
+            $ref: '#/definitions/smsgateway.MobileUserCodeResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - ApiAuth: []
+      - ApiAuth: []
       summary: Get one-time code for device registration
       tags:
-        - Device
+      - Device
   /mobile/v1/user/password:
     patch:
       consumes:
-        - application/json
+      - application/json
       description: Changes the user's password
       parameters:
-        - description: Password change request
-          in: body
-          name: request
-          required: true
-          schema:
-            $ref: "#/definitions/smsgateway.MobileChangePasswordRequest"
+      - description: Password change request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/smsgateway.MobileChangePasswordRequest'
       produces:
-        - application/json
+      - application/json
       responses:
         "204":
           description: Password changed successfully
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - MobileToken: []
+      - MobileToken: []
       summary: Change password
       tags:
-        - Device
+      - Device
   /mobile/v1/webhooks:
     get:
       description: Returns list of registered webhooks for device
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: Webhook list
           schema:
             items:
-              $ref: "#/definitions/smsgateway.Webhook"
+              $ref: '#/definitions/smsgateway.Webhook'
             type: array
         "401":
           description: Unauthorized
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       security:
-        - MobileToken: []
+      - MobileToken: []
       summary: List webhooks
       tags:
-        - Device
-        - Webhooks
+      - Device
+      - Webhooks
   /upstream/v1/push:
     post:
       consumes:
-        - application/json
+      - application/json
       description: Enqueues notifications for sending to devices
       parameters:
-        - description: Push request
-          in: body
-          name: request
-          required: true
-          schema:
-            items:
-              $ref: "#/definitions/smsgateway.PushNotification"
-            type: array
+      - description: Push request
+        in: body
+        name: request
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/smsgateway.PushNotification'
+          type: array
       produces:
-        - application/json
+      - application/json
       responses:
         "202":
           description: Notification enqueued
         "400":
           description: Invalid request
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "429":
           description: Too many requests
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:
-            $ref: "#/definitions/smsgateway.ErrorResponse"
+            $ref: '#/definitions/smsgateway.ErrorResponse'
       summary: Send push notifications
       tags:
-        - Upstream
+      - Upstream
 schemes:
-  - https
+- https
 securityDefinitions:
   ApiAuth:
     type: basic

--- a/pkg/swagger/docs/swagger.yaml
+++ b/pkg/swagger/docs/swagger.yaml
@@ -900,6 +900,11 @@ paths:
         in: query
         name: skipPhoneValidation
         type: boolean
+      - default: 0
+        description: Filter devices active within the specified number of hours
+        in: query
+        name: deviceActiveWithin
+        type: integer
       - description: Send message request
         in: body
         name: request

--- a/pkg/swagger/docs/swagger.yaml
+++ b/pkg/swagger/docs/swagger.yaml
@@ -893,8 +893,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Enqueues message for sending. If multiple devices are registered,
-        it will be sent via a random one
+      description: Enqueues a message for sending. If `deviceId` is set, the specified
+        device is used; otherwise a random registered device is chosen.
       parameters:
       - description: Skip phone validation
         in: query
@@ -903,6 +903,7 @@ paths:
       - default: 0
         description: Filter devices active within the specified number of hours
         in: query
+        minimum: 0
         name: deviceActiveWithin
         type: integer
       - description: Send message request

--- a/test/e2e/device_selection_test.go
+++ b/test/e2e/device_selection_test.go
@@ -42,7 +42,9 @@ func TestDeviceSelection(t *testing.T) {
 	}
 
 	req := map[string]any{
-		"message": "test",
+		"textMessage": map[string]any{
+			"text": "test",
+		},
 		"phoneNumbers": []string{
 			"+79999999999",
 		},

--- a/test/e2e/device_selection_test.go
+++ b/test/e2e/device_selection_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/capcom6/go-helpers/anys"
+)
+
+func TestDeviceSelection(t *testing.T) {
+	// Register first device
+	firstDevice := mobileDeviceRegister(t, publicMobileClient)
+	client := publicUserClient.SetBasicAuth(firstDevice.Login, firstDevice.Password)
+
+	// Register a second device to test explicit device selection
+	secondDevice := mobileDeviceRegister(
+		t,
+		publicMobileClient,
+		(&mobileDeviceRegisterOptions{}).
+			withCredentials(firstDevice.Login, firstDevice.Password),
+	)
+
+	cases := []struct {
+		name               string
+		deviceID           *string
+		expectedStatusCode int
+	}{
+		{
+			name:               "explicit device selection",
+			deviceID:           anys.AsPointer(secondDevice.ID),
+			expectedStatusCode: 202,
+		},
+		{
+			name:               "invalid device ID",
+			deviceID:           anys.AsPointer("invalid-device-id"),
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "no device ID (random selection)",
+			deviceID:           nil,
+			expectedStatusCode: 202,
+		},
+	}
+
+	req := map[string]any{
+		"message": "test",
+		"phoneNumbers": []string{
+			"+79999999999",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.deviceID != nil {
+				req["deviceId"] = *c.deviceID
+			} else {
+				delete(req, "deviceId")
+			}
+			res, err := client.R().
+				SetHeader("Content-Type", "application/json").
+				SetBody(req).
+				Post("messages")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode() != c.expectedStatusCode {
+				t.Fatal(res.StatusCode(), res.String())
+			}
+		})
+	}
+}

--- a/test/e2e/mobile_test.go
+++ b/test/e2e/mobile_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 type mobileRegisterResponse struct {
+	ID       string `json:"id"`
 	Token    string `json:"token"`
 	Login    string `json:"login"`
 	Password string `json:"password"`

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -7,8 +7,26 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-func mobileDeviceRegister(t *testing.T, client *resty.Client) mobileRegisterResponse {
-	res, err := client.R().
+type mobileDeviceRegisterOptions struct {
+	username string
+	password string
+}
+
+func (o *mobileDeviceRegisterOptions) withCredentials(username, password string) *mobileDeviceRegisterOptions {
+	o.username = username
+	o.password = password
+	return o
+}
+
+func mobileDeviceRegister(t *testing.T, client *resty.Client, opts ...*mobileDeviceRegisterOptions) mobileRegisterResponse {
+	req := client.R()
+	for _, opt := range opts {
+		if opt.username != "" && opt.password != "" {
+			req.SetBasicAuth(opt.username, opt.password)
+		}
+	}
+
+	res, err := req.
 		SetHeader("Content-Type", "application/json").
 		SetBody(`{"name": "Public Device Name", "pushToken": "token"}`).
 		Post("device")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering devices by recent activity when sending messages.
  * Added support for explicitly selecting a device by its ID when sending messages via the API.
  * Updated API documentation and schemas to include an optional device ID field for message requests and exports, and to require device ID in message state responses.
  * Changed message state response format to a new detailed structure including device ID and message metadata.

* **Bug Fixes**
  * Device ID is now consistently included in message state representations.
  * Enhanced error messages for content unmarshalling failures.
  * Health checks now fail safely on unknown statuses.

* **Tests**
  * Introduced end-to-end tests to verify device selection behavior, including explicit, invalid, and random device selection scenarios.
  * Enhanced test utilities to support device registration with authentication credentials.

* **Style**
  * Improved formatting and consistency in the Swagger API YAML documentation.

* **Refactor**
  * Updated message state handling to use new internal structured types for input and output.
  * Modified mobile message patch endpoint to accept updated request format with detailed message state objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->