### PR TITLE
[db] remove deprecated message field

### DIFF
--- a/internal/sms-gateway/models/migrations/mysql/20250708232157_remove_message_field.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20250708232157_remove_message_field.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `messages` DROP `message`;
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE `messages`
+ADD `message` text NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE `messages`
+SET `message` = CASE
+        WHEN `is_hashed` = 0 THEN COALESCE(
+            JSON_VALUE(`content`, '$.text'),
+            JSON_VALUE(`content`, '$.data')
+        )
+        ELSE `content`
+    END;
+-- +goose StatementEnd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the database schema to remove the message field from the messages table. The field will be restored with data reconstruction if the change is rolled back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->