### PR TITLE
[deploy] use of ghcr instead of Docker Hub

### DIFF
--- a/deployments/docker-swarm-terraform/main.tf
+++ b/deployments/docker-swarm-terraform/main.tf
@@ -7,7 +7,7 @@ data "docker_network" "internal" {
 }
 
 resource "docker_image" "app" {
-  name         = "capcom6/${var.app-name}:${var.app-version}"
+  name         = "ghcr.io/android-sms-gateway/server:${var.app-version}"
   keep_locally = true
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment to pull the server image from ghcr.io/android-sms-gateway/server using the existing version tag.
  * Applies to all environments using the containerized server.
  * App behavior and configuration remain unchanged; no user-facing changes are expected.
  * Existing rollout processes and versioning remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->