### PR TITLE
[mobile] messages processing order param

### DIFF
--- a/internal/sms-gateway/handlers/base/handler.go
+++ b/internal/sms-gateway/handlers/base/handler.go
@@ -43,7 +43,7 @@ func (h *Handler) ParamsParserValidator(c *fiber.Ctx, out any) error {
 
 func (h *Handler) ValidateStruct(out any) error {
 	if h.Validator != nil {
-		if err := h.Validator.Struct(out); err != nil {
+		if err := h.Validator.Var(out, "required,dive"); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 	}

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -60,7 +60,7 @@ type ThirdPartyController struct {
 //
 // Enqueue message
 func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
-	var params postQueryParams
+	var params thirdPartyPostQueryParams
 	if err := h.QueryParserValidator(c, &params); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
@@ -190,7 +190,7 @@ func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
 //
 // Get message history
 func (h *ThirdPartyController) list(user models.User, c *fiber.Ctx) error {
-	params := getQueryParams{}
+	params := thirdPartyGetQueryParams{}
 	if err := h.QueryParserValidator(c, &params); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -62,12 +62,12 @@ type ThirdPartyController struct {
 func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
 	var params thirdPartyPostQueryParams
 	if err := h.QueryParserValidator(c, &params); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	var req smsgateway.Message
 	if err := h.BodyParserValidator(c, &req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	var device models.Device
@@ -192,7 +192,7 @@ func (h *ThirdPartyController) post(user models.User, c *fiber.Ctx) error {
 func (h *ThirdPartyController) list(user models.User, c *fiber.Ctx) error {
 	params := thirdPartyGetQueryParams{}
 	if err := h.QueryParserValidator(c, &params); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	messages, total, err := h.messagesSvc.SelectStates(user, params.ToFilter(), params.ToOptions())
@@ -252,7 +252,7 @@ func (h *ThirdPartyController) get(user models.User, c *fiber.Ctx) error {
 func (h *ThirdPartyController) postInboxExport(user models.User, c *fiber.Ctx) error {
 	req := smsgateway.MessagesExportRequest{}
 	if err := h.BodyParserValidator(c, &req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	device, err := h.devicesSvc.Get(user.ID, devices.WithID(req.DeviceID))

--- a/internal/sms-gateway/handlers/messages/mobile.go
+++ b/internal/sms-gateway/handlers/messages/mobile.go
@@ -1,0 +1,122 @@
+package messages
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/android-sms-gateway/client-go/smsgateway"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/base"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/converters"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/middlewares/deviceauth"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/models"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
+	"github.com/capcom6/go-helpers/slices"
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/fx"
+	"go.uber.org/zap"
+)
+
+type mobileControllerParams struct {
+	fx.In
+
+	MessagesSvc *messages.Service
+
+	Validator *validator.Validate
+	Logger    *zap.Logger
+}
+
+type MobileController struct {
+	base.Handler
+
+	messagesSvc *messages.Service
+}
+
+//	@Summary		Get messages for sending
+//	@Description	Returns list of pending messages
+//	@Security		MobileToken
+//	@Tags			Device, Messages
+//	@Accept			json
+//	@Produce		json
+//	@Param			order	query		string									false	"Message processing order: lifo (default) or fifo"	Enums(lifo,fifo) default(lifo)
+//	@Success		200		{object}	smsgateway.MobileGetMessagesResponse	"List of pending messages"
+//	@Failure		400		{object}	smsgateway.ErrorResponse				"Invalid request"
+//	@Failure		500		{object}	smsgateway.ErrorResponse				"Internal server error"
+//	@Router			/mobile/v1/message [get]
+//
+// Get messages for sending
+func (h *MobileController) list(device models.Device, c *fiber.Ctx) error {
+	// Get and validate order parameter
+	params := mobileGetQueryParams{}
+	if err := h.QueryParserValidator(c, &params); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	msgs, err := h.messagesSvc.SelectPending(device.ID, params.OrderOrDefault())
+	if err != nil {
+		return fmt.Errorf("can't get messages: %w", err)
+	}
+
+	return c.JSON(
+		smsgateway.MobileGetMessagesResponse(
+			slices.Map(
+				msgs,
+				converters.MessageToMobileDTO,
+			),
+		),
+	)
+}
+
+//	@Summary		Update message state
+//	@Description	Updates message state
+//	@Security		MobileToken
+//	@Tags			Device, Messages
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		smsgateway.MobilePatchMessageRequest	true	"List of message state updates"
+//	@Success		204		{object}	nil										"Successfully updated"
+//	@Failure		400		{object}	smsgateway.ErrorResponse				"Invalid request"
+//	@Failure		500		{object}	smsgateway.ErrorResponse				"Internal server error"
+//	@Router			/mobile/v1/message [patch]
+//
+// Update message state
+func (h *MobileController) patch(device models.Device, c *fiber.Ctx) error {
+	var req smsgateway.MobilePatchMessageRequest
+	if err := h.BodyParserValidator(c, &req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	for _, v := range req {
+		messageState := messages.MessageStateIn{
+			ID:         v.ID,
+			State:      messages.ProcessingState(v.State),
+			Recipients: v.Recipients,
+			States:     v.States,
+		}
+
+		err := h.messagesSvc.UpdateState(device.ID, messageState)
+		if err != nil && !errors.Is(err, messages.ErrMessageNotFound) {
+			h.Logger.Error("Can't update message status",
+				zap.String("message_id", v.ID),
+				zap.Error(err),
+			)
+		}
+	}
+
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+func (h *MobileController) Register(router fiber.Router) {
+	router.Get("", deviceauth.WithDevice(h.list))
+	router.Patch("", deviceauth.WithDevice(h.patch))
+}
+
+func NewMobileController(params mobileControllerParams) *MobileController {
+	return &MobileController{
+		Handler: base.Handler{
+			Logger:    params.Logger.Named("messages"),
+			Validator: params.Validator,
+		},
+		messagesSvc: params.MessagesSvc,
+	}
+}

--- a/internal/sms-gateway/handlers/messages/mobile.go
+++ b/internal/sms-gateway/handlers/messages/mobile.go
@@ -49,7 +49,7 @@ func (h *MobileController) list(device models.Device, c *fiber.Ctx) error {
 	// Get and validate order parameter
 	params := mobileGetQueryParams{}
 	if err := h.QueryParserValidator(c, &params); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	msgs, err := h.messagesSvc.SelectPending(device.ID, params.OrderOrDefault())
@@ -81,9 +81,9 @@ func (h *MobileController) list(device models.Device, c *fiber.Ctx) error {
 //
 // Update message state
 func (h *MobileController) patch(device models.Device, c *fiber.Ctx) error {
-	var req smsgateway.MobilePatchMessageRequest
+	req := smsgateway.MobilePatchMessageRequest{}
 	if err := h.BodyParserValidator(c, &req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	for _, v := range req {

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -7,12 +7,12 @@ import (
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
 )
 
-type postQueryParams struct {
+type thirdPartyPostQueryParams struct {
 	SkipPhoneValidation bool `query:"skipPhoneValidation"`
 	DeviceActiveWithin  uint `query:"deviceActiveWithin"`
 }
 
-type getQueryParams struct {
+type thirdPartyGetQueryParams struct {
 	StartDate string `query:"from" validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
 	EndDate   string `query:"to" validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
 	State     string `query:"state" validate:"omitempty,oneof=Pending Processed Sent Delivered Failed"`
@@ -21,7 +21,7 @@ type getQueryParams struct {
 	Offset    int    `query:"offset" validate:"omitempty,min=0"`
 }
 
-func (p *getQueryParams) Validate() error {
+func (p *thirdPartyGetQueryParams) Validate() error {
 	if p.StartDate != "" && p.EndDate != "" && p.StartDate > p.EndDate {
 		return fmt.Errorf("`from` date must be before `to` date")
 	}
@@ -29,7 +29,7 @@ func (p *getQueryParams) Validate() error {
 	return nil
 }
 
-func (p *getQueryParams) ToFilter() messages.MessagesSelectFilter {
+func (p *thirdPartyGetQueryParams) ToFilter() messages.MessagesSelectFilter {
 	filter := messages.MessagesSelectFilter{}
 
 	if p.StartDate != "" {
@@ -55,7 +55,7 @@ func (p *getQueryParams) ToFilter() messages.MessagesSelectFilter {
 	return filter
 }
 
-func (p *getQueryParams) ToOptions() messages.MessagesSelectOptions {
+func (p *thirdPartyGetQueryParams) ToOptions() messages.MessagesSelectOptions {
 	options := messages.MessagesSelectOptions{
 		WithRecipients: true,
 		WithStates:     true,
@@ -72,4 +72,16 @@ func (p *getQueryParams) ToOptions() messages.MessagesSelectOptions {
 	}
 
 	return options
+}
+
+type mobileGetQueryParams struct {
+	Order messages.MessagesOrder `query:"order" validate:"omitempty,oneof=lifo fifo"`
+}
+
+func (p *mobileGetQueryParams) OrderOrDefault() messages.MessagesOrder {
+	if p.Order != "" {
+		return p.Order
+	}
+	return messages.MessagesOrderLIFO
+
 }

--- a/internal/sms-gateway/handlers/mobile.go
+++ b/internal/sms-gateway/handlers/mobile.go
@@ -96,7 +96,7 @@ func (h *mobileHandler) postDevice(c *fiber.Ctx) (err error) {
 	req := smsgateway.MobileRegisterRequest{}
 
 	if err = h.BodyParserValidator(c, &req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	var (
@@ -150,7 +150,7 @@ func (h *mobileHandler) patchDevice(device models.Device, c *fiber.Ctx) error {
 	req := smsgateway.MobileUpdateRequest{}
 
 	if err := h.BodyParserValidator(c, &req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	if req.Id != device.ID {
@@ -205,7 +205,7 @@ func (h *mobileHandler) changePassword(device models.Device, c *fiber.Ctx) error
 	req := smsgateway.MobileChangePasswordRequest{}
 
 	if err := h.BodyParserValidator(c, &req); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		return err
 	}
 
 	if err := h.authSvc.ChangePassword(device.UserID, req.CurrentPassword, req.NewPassword); err != nil {

--- a/internal/sms-gateway/handlers/module.go
+++ b/internal/sms-gateway/handlers/module.go
@@ -26,6 +26,7 @@ var Module = fx.Module(
 	fx.Provide(
 		newHealthHandler,
 		messages.NewThirdPartyController,
+		messages.NewMobileController,
 		webhooks.NewThirdPartyController,
 		webhooks.NewMobileController,
 		devices.NewThirdPartyController,

--- a/internal/sms-gateway/modules/messages/repository_filter.go
+++ b/internal/sms-gateway/modules/messages/repository_filter.go
@@ -2,6 +2,17 @@ package messages
 
 import "time"
 
+// MessagesOrder defines supported ordering for message selection.
+// Valid values: "lifo" (default), "fifo".
+type MessagesOrder string
+
+const (
+	// MessagesOrderLIFO orders messages newest-first within the same priority (default).
+	MessagesOrderLIFO MessagesOrder = "lifo"
+	// MessagesOrderFIFO orders messages oldest-first within the same priority.
+	MessagesOrderFIFO MessagesOrder = "fifo"
+)
+
 type MessagesSelectFilter struct {
 	ExtID     string
 	UserID    string
@@ -15,6 +26,10 @@ type MessagesSelectOptions struct {
 	WithRecipients bool
 	WithDevice     bool
 	WithStates     bool
+
+	// OrderBy sets the retrieval order for pending messages.
+	// Empty (zero) value defaults to "lifo".
+	OrderBy MessagesOrder
 
 	Limit  int
 	Offset int

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -92,8 +92,12 @@ func (s *Service) RunBackgroundTasks(ctx context.Context, wg *sync.WaitGroup) {
 	}()
 }
 
-func (s *Service) SelectPending(deviceID string) ([]MessageOut, error) {
-	messages, err := s.messages.SelectPending(deviceID)
+func (s *Service) SelectPending(deviceID string, order MessagesOrder) ([]MessageOut, error) {
+	if order == "" {
+		order = MessagesOrderLIFO
+	}
+
+	messages, err := s.messages.SelectPending(deviceID, order)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/swagger/docs/swagger.json
+++ b/pkg/swagger/docs/swagger.json
@@ -982,6 +982,19 @@
                     "Messages"
                 ],
                 "summary": "Get messages for sending",
+                "parameters": [
+                    {
+                        "enum": [
+                            "lifo",
+                            "fifo"
+                        ],
+                        "type": "string",
+                        "default": "lifo",
+                        "description": "Message processing order: lifo (default) or fifo",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "List of pending messages",
@@ -990,6 +1003,12 @@
                             "items": {
                                 "$ref": "#/definitions/smsgateway.MobileMessage"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.ErrorResponse"
                         }
                     },
                     "500": {

--- a/pkg/swagger/docs/swagger.yaml
+++ b/pkg/swagger/docs/swagger.yaml
@@ -1417,6 +1417,15 @@ paths:
       consumes:
       - application/json
       description: Returns list of pending messages
+      parameters:
+      - default: lifo
+        description: 'Message processing order: lifo (default) or fifo'
+        enum:
+        - lifo
+        - fifo
+        in: query
+        name: order
+        type: string
       produces:
       - application/json
       responses:
@@ -1426,6 +1435,10 @@ paths:
             items:
               $ref: '#/definitions/smsgateway.MobileMessage'
             type: array
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/smsgateway.ErrorResponse'
         "500":
           description: Internal server error
           schema:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GET /mobile/v1/message: add order query (lifo default or fifo) to control retrieval.
  - PATCH /mobile/v1/message: accept batched message-state updates.

- **Documentation**
  - API docs updated: new order parameter, updated summary/tags, and 400 Bad Request for invalid GET requests.

- **Refactor**
  - Message handling moved to a dedicated controller and routed modularly.

- **Behavior**
  - Pending fetch capped to a max batch size (100) and supports FIFO/LIFO ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->