### PR TITLE
[examples] fix env variables names

### DIFF
--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -17,8 +17,8 @@ database: # database
   max_idle_conns: 2 # database max idle connections (default: 2 * CPU) [DATABASE__MAX_IDLE_CONNS]
 fcm: # firebase cloud messaging config
   credentials_json: "{}" # firebase credentials json (for public mode only) [FCM__CREDENTIALS_JSON]
-  timeout_seconds: 1 # push notification send timeout [FCM__DEBOUNCE_SECONDS]
-  debounce_seconds: 5 # push notification debounce (>= 5s) [FCM__TIMEOUT_SECONDS]
+  timeout_seconds: 1 # push notification send timeout [FCM__TIMEOUT_SECONDS]
+  debounce_seconds: 5 # push notification debounce (>= 5s) [FCM__DEBOUNCE_SECONDS]
 tasks: # tasks config
   hashing: # hashing task (hashes processed messages for privacy purposes)
     interval_seconds: 15 # hashing interval in seconds [TASKS__HASHING__INTERVAL_SECONDS]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example configuration to clarify FCM environment variables:
    - timeout_seconds maps to FCM__TIMEOUT_SECONDS (default 1).
    - debounce_seconds maps to FCM__DEBOUNCE_SECONDS (default 5).
  * No other configuration values changed.
  * If configuring via environment variables, verify names to ensure correct setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->