### PR TITLE
[devices] store empty token as null

### DIFF
--- a/internal/sms-gateway/models/migrations/mysql/20260402000000_normalize_push_token.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260402000000_normalize_push_token.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE `devices`
+SET `push_token` = NULL
+WHERE `push_token` = '';
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd

--- a/internal/sms-gateway/modules/devices/repository.go
+++ b/internal/sms-gateway/modules/devices/repository.go
@@ -74,7 +74,7 @@ func (r *Repository) Insert(device *models.Device) error {
 	return r.db.Create(device).Error
 }
 
-func (r *Repository) UpdatePushToken(id, token string) error {
+func (r *Repository) UpdatePushToken(id string, token *string) error {
 	res := r.db.Model((*models.Device)(nil)).Where("id = ?", id).Update("push_token", token)
 	if res.Error != nil {
 		return fmt.Errorf("failed to update device: %w", res.Error)

--- a/internal/sms-gateway/modules/devices/service.go
+++ b/internal/sms-gateway/modules/devices/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/android-sms-gateway/server/internal/sms-gateway/models"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/db"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 )
 
@@ -134,7 +135,7 @@ func (s *Service) UpdatePushToken(id string, token string) error {
 		)
 	}
 
-	if err := s.devices.UpdatePushToken(id, token); err != nil {
+	if err := s.devices.UpdatePushToken(id, lo.EmptyableToPtr(token)); err != nil {
 		return err
 	}
 

--- a/internal/sms-gateway/modules/events/service.go
+++ b/internal/sms-gateway/modules/events/service.go
@@ -130,7 +130,7 @@ func (s *Service) processEvent(wrapper *eventWrapper) {
 
 	// Process each device
 	for _, device := range devices {
-		if device.PushToken != nil && *device.PushToken != "" {
+		if device.PushToken != nil {
 			// Device has push token, use push service
 			if enqErr := s.pushSvc.Enqueue(*device.PushToken, push.Event{
 				Type: wrapper.Event.EventType,


### PR DESCRIPTION
### Motivation
- Ensure empty FCM/push tokens are stored as SQL `NULL` instead of empty strings so downstream logic and DB semantics treat missing tokens consistently.

### Description
- Convert incoming empty push token (`""`) to `nil` in `Service.UpdatePushToken` before persistence by creating a `*string` `pushToken` and setting it only when non-empty; file modified: `internal/sms-gateway/modules/devices/service.go`.
- Change repository method signature to accept `*string` and write the pointer directly to the `push_token` column so `nil` becomes SQL `NULL`; file modified: `internal/sms-gateway/modules/devices/repository.go`.
- Update the service → repository call to pass the `*string` value instead of the raw string so NULLs are persisted when token is empty.

### Testing
- Ran `go test ./internal/sms-gateway/modules/devices/...` which reported no test files for that package and completed without errors.
- Ran `go test ./internal/sms-gateway/...` and existing tests executed successfully (all tested packages passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdf411f65c832cacbd7a7477c8b6f2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Push token handling changed so empty input now clears the stored token; services forward removals and cache invalidation remains intact.
* **Behavior**
  * Devices with a cleared (now-null) push token are treated as eligible for push delivery instead of falling back to SSE.
* **Database Migration**
  * Migration converts existing empty push tokens to NULL to align stored values with the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->