### PR TITLE
[messages] provide content with the state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,13 @@ init-dev: init
 ngrok:
 	ngrok http 3000
 
-air:
-	air
+air: ## Run development server
+	@command -v air >/dev/null 2>&1 || { \
+      echo "Please install air: go install github.com/air-verse/air@latest"; \
+      exit 1; \
+    }
+	@echo "Starting development server with air..."
+	TZ=UTC DEBUG=1 air
 
 db-upgrade:
 	go run ./cmd/$(project_name)/main.go db:migrate

--- a/api/local.http
+++ b/api/local.http
@@ -8,11 +8,12 @@ GET {{localUrl}}/health HTTP/1.1
 
 ###
 GET {{localUrl}}/device HTTP/1.1
-# Authorization: Basic {{localCredentials}}
-Authorization: Bearer {{localToken}}
+Authorization: Basic {{localCredentials}}
 
 ###
-POST {{localUrl}}/message?skipPhoneValidation=false HTTP/1.1
+# @name sendMessage
+@messageId={{sendMessage.response.body.$.id}}
+POST {{localUrl}}/messages?skipPhoneValidation=false HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{localCredentials}}
 
@@ -22,12 +23,12 @@ Authorization: Basic {{localCredentials}}
     "phoneNumbers": [
         "{{phone}}"
     ],
-    "simNumber": 1,
+    "simNumber": {{$randomInt 0 3}},
     "withDeliveryReport": true
 }
 
 ###
-POST {{localUrl}}/message HTTP/1.1
+POST {{localUrl}}/messages HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{localCredentials}}
 
@@ -41,7 +42,7 @@ Authorization: Basic {{localCredentials}}
 }
 
 ###
-POST {{localUrl}}/message HTTP/1.1
+POST {{localUrl}}/messages HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{localCredentials}}
 
@@ -56,7 +57,7 @@ Authorization: Basic {{localCredentials}}
 }
 
 ###
-POST {{localUrl}}/message HTTP/1.1
+POST {{localUrl}}/messages HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{localCredentials}}
 
@@ -70,7 +71,7 @@ Authorization: Basic {{localCredentials}}
 }
 
 ###
-POST {{localUrl}}/message HTTP/1.1
+POST {{localUrl}}/messages HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{localCredentials}}
 
@@ -94,18 +95,18 @@ GET {{localUrl}}/messages?includeContent=true HTTP/1.1
 Authorization: Basic {{localCredentials}}
 
 ###
-GET {{localUrl}}/message/8GN2Pz-fzu73NL3398ROE HTTP/1.1
+GET {{localUrl}}/messages/{{messageId}} HTTP/1.1
 Authorization: Basic {{localCredentials}}
 
 ###
 GET {{localUrl}}/webhooks HTTP/1.1
-# Authorization: Basic {{localCredentials}}
-Authorization: Bearer {{localToken}}
+Authorization: Basic {{localCredentials}}
 
 ###
+# @name createWebhook
+@webhookId={{createWebhook.response.body.$.id}}
 POST {{localUrl}}/webhooks HTTP/1.1
-# Authorization: Basic {{localCredentials}}
-Authorization: Bearer {{localToken}}
+Authorization: Basic {{localCredentials}}
 Content-Type: application/json
 
 {
@@ -115,7 +116,7 @@ Content-Type: application/json
 }
 
 ###
-DELETE {{localUrl}}/webhooks/LreFUt-Z3sSq0JufY9uWB HTTP/1.1
+DELETE {{localUrl}}/webhooks/{{webhookId}} HTTP/1.1
 Authorization: Basic {{localCredentials}}
 
 ###
@@ -177,6 +178,8 @@ Content-Type: application/json
 
 ###
 # @name issueToken
+@jti={{issueToken.response.body.$.id}}
+@accessToken={{issueToken.response.body.$.access_token}}
 POST {{localUrl}}/auth/token HTTP/1.1
 Authorization: Basic {{localCredentials}}
 Content-Type: application/json
@@ -189,6 +192,5 @@ Content-Type: application/json
 }
 
 ###
-@jti={{issueToken.response.body.$.id}}
 DELETE {{localUrl}}/auth/token/{{jti}} HTTP/1.1
 Authorization: Basic {{localCredentials}}

--- a/api/local.http
+++ b/api/local.http
@@ -86,6 +86,14 @@ Authorization: Basic {{localCredentials}}
 }
 
 ###
+GET {{localUrl}}/messages HTTP/1.1
+Authorization: Basic {{localCredentials}}
+
+###
+GET {{localUrl}}/messages?includeContent=true HTTP/1.1
+Authorization: Basic {{localCredentials}}
+
+###
 GET {{localUrl}}/message/8GN2Pz-fzu73NL3398ROE HTTP/1.1
 Authorization: Basic {{localCredentials}}
 

--- a/api/requests.http
+++ b/api/requests.http
@@ -35,8 +35,8 @@ Authorization: Basic {{credentials}}
 ###
 POST {{baseUrl}}/3rdparty/v1/messages HTTP/1.1
 Content-Type: application/json
-# Authorization: Basic {{credentials}}
-Authorization: Bearer {{jwtToken}}
+Authorization: Basic {{credentials}}
+# Authorization: Bearer {{jwtToken}}
 
 {
     "textMessage": {
@@ -63,6 +63,7 @@ Authorization: Basic {{credentials}}
 }
 
 ###
+# @name enqueueMessage
 POST {{baseUrl}}/3rdparty/v1/messages HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{credentials}}
@@ -79,14 +80,20 @@ Authorization: Basic {{credentials}}
 }
 
 ###
-GET {{baseUrl}}/3rdparty/v1/messages/Fc10ZyTRDVlqPjIm9Jbly HTTP/1.1
-# Authorization: Basic {{credentials}}
-Authorization: Bearer {{jwtToken}}
+@messageId={{enqueueMessage.response.body.$.id}}
+GET {{baseUrl}}/3rdparty/v1/messages/{{messageId}} HTTP/1.1
+Authorization: Basic {{credentials}}
+# Authorization: Bearer {{jwtToken}}
 
 ###
 GET {{baseUrl}}/3rdparty/v1/messages HTTP/1.1
-# Authorization: Basic {{credentials}}
-Authorization: Bearer {{jwtToken}}
+Authorization: Basic {{credentials}}
+# Authorization: Bearer {{jwtToken}}
+
+###
+GET {{baseUrl}}/3rdparty/v1/messages?includeContent=true HTTP/1.1
+Authorization: Basic {{credentials}}
+# Authorization: Bearer {{jwtToken}}
 
 ###
 GET {{baseUrl}}/3rdparty/v1/messages?from=2025-01-01T00:00:00.000Z&to=2025-12-31T23:59:59Z&state=Pending&deviceId=fL2m4IirEvh9BvTf6TIB0&limit=50&offset=0 HTTP/1.1
@@ -105,8 +112,8 @@ Content-Type: application/json
 
 ###
 GET {{baseUrl}}/3rdparty/v1/devices HTTP/1.1
-# Authorization: Basic {{credentials}}
-Authorization: Bearer {{jwtToken}}
+Authorization: Basic {{credentials}}
+# Authorization: Bearer {{jwtToken}}
 
 
 ###

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	firebase.google.com/go/v4 v4.19.0
-	github.com/android-sms-gateway/client-go v1.12.1
+	github.com/android-sms-gateway/client-go v1.12.3
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/capcom6/go-helpers v0.3.0
 	github.com/capcom6/go-infra-fx v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/android-sms-gateway/client-go v1.12.1 h1:eiWF6CEl4dW4xXXt8nNQNM0+IgZuo6pV0ngILV6v8Ow=
-github.com/android-sms-gateway/client-go v1.12.1/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.12.3 h1:ToyjxJ1JxP9oKXsAMoBFT8qNFK8f0s3EYrOyASks27g=
+github.com/android-sms-gateway/client-go v1.12.3/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=

--- a/internal/sms-gateway/handlers/converters/messages.go
+++ b/internal/sms-gateway/handlers/converters/messages.go
@@ -5,7 +5,7 @@ import (
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
 )
 
-func MessageToMobileDTO(m messages.MessageOut) smsgateway.MobileMessage {
+func MessageToMobileDTO(m messages.Message) smsgateway.MobileMessage {
 	var message string
 	var textMessage *smsgateway.TextMessage
 	var dataMessage *smsgateway.DataMessage
@@ -43,7 +43,7 @@ func MessageToMobileDTO(m messages.MessageOut) smsgateway.MobileMessage {
 	}
 }
 
-func MessageStateToDTO(state messages.MessageStateOut) smsgateway.MessageState {
+func MessageStateToDTO(state messages.MessageState) smsgateway.MessageState {
 	return smsgateway.MessageState{
 		ID:          state.ID,
 		DeviceID:    state.DeviceID,
@@ -52,5 +52,9 @@ func MessageStateToDTO(state messages.MessageStateOut) smsgateway.MessageState {
 		IsEncrypted: state.IsEncrypted,
 		Recipients:  state.Recipients,
 		States:      state.States,
+
+		TextMessage:   state.TextContent,
+		DataMessage:   state.DataContent,
+		HashedMessage: state.HashedContent,
 	}
 }

--- a/internal/sms-gateway/handlers/converters/messages_test.go
+++ b/internal/sms-gateway/handlers/converters/messages_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/android-sms-gateway/client-go/smsgateway"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/converters"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
-	"github.com/capcom6/go-helpers/anys"
 	"github.com/go-playground/assert/v2"
+	"github.com/samber/lo"
 )
 
 func TestMessageToDTO(t *testing.T) {
@@ -18,21 +18,24 @@ func TestMessageToDTO(t *testing.T) {
 	// Define test cases
 	tests := []struct {
 		name     string
-		input    messages.MessageOut
+		input    messages.Message
 		expected smsgateway.MobileMessage
 	}{
 		{
 			name: "Full message with all fields",
-			input: messages.MessageOut{
-				MessageIn: messages.MessageIn{
+			input: messages.Message{
+				MessageInput: messages.MessageInput{
+					MessageContent: messages.MessageContent{
+						TextContent: &messages.TextMessageContent{Text: "Test message content"},
+					},
+
 					ID:                 "msg-123",
-					TextContent:        &messages.TextMessageContent{Text: "Test message content"},
 					PhoneNumbers:       []string{"+1234567890", "+9876543210"},
 					IsEncrypted:        true,
-					SimNumber:          anys.AsPointer(uint8(2)),
-					WithDeliveryReport: anys.AsPointer(true),
-					TTL:                anys.AsPointer(uint64(3600)),
-					ValidUntil:         anys.AsPointer(now.Add(24 * time.Hour)),
+					SimNumber:          lo.ToPtr(uint8(2)),
+					WithDeliveryReport: lo.ToPtr(true),
+					TTL:                lo.ToPtr(uint64(3600)),
+					ValidUntil:         lo.ToPtr(now.Add(24 * time.Hour)),
 					Priority:           100,
 				},
 				CreatedAt: now,
@@ -44,10 +47,10 @@ func TestMessageToDTO(t *testing.T) {
 					TextMessage:        &smsgateway.TextMessage{Text: "Test message content"},
 					PhoneNumbers:       []string{"+1234567890", "+9876543210"},
 					IsEncrypted:        true,
-					SimNumber:          anys.AsPointer(uint8(2)),
-					WithDeliveryReport: anys.AsPointer(true),
-					TTL:                anys.AsPointer(uint64(3600)),
-					ValidUntil:         anys.AsPointer(now.Add(24 * time.Hour)),
+					SimNumber:          lo.ToPtr(uint8(2)),
+					WithDeliveryReport: lo.ToPtr(true),
+					TTL:                lo.ToPtr(uint64(3600)),
+					ValidUntil:         lo.ToPtr(now.Add(24 * time.Hour)),
 					Priority:           100,
 				},
 				CreatedAt: now,
@@ -55,10 +58,13 @@ func TestMessageToDTO(t *testing.T) {
 		},
 		{
 			name: "Minimal message with required fields only",
-			input: messages.MessageOut{
-				MessageIn: messages.MessageIn{
+			input: messages.Message{
+				MessageInput: messages.MessageInput{
+					MessageContent: messages.MessageContent{
+						TextContent: &messages.TextMessageContent{Text: "Another test message"},
+					},
+
 					ID:           "msg-456",
-					TextContent:  &messages.TextMessageContent{Text: "Another test message"},
 					PhoneNumbers: []string{"+1122334455"},
 				},
 				CreatedAt: now,

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -114,11 +114,13 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "No message content provided")
 	}
 
-	msg := messages.MessageIn{
-		ID: req.ID,
+	msg := messages.MessageInput{
+		MessageContent: messages.MessageContent{
+			TextContent: textContent,
+			DataContent: dataContent,
+		},
 
-		TextContent: textContent,
-		DataContent: dataContent,
+		ID: req.ID,
 
 		PhoneNumbers: req.PhoneNumbers,
 		IsEncrypted:  req.IsEncrypted,
@@ -160,15 +162,7 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusAccepted).
-		JSON(smsgateway.GetMessageResponse{
-			ID:          state.ID,
-			DeviceID:    state.DeviceID,
-			State:       smsgateway.ProcessingState(state.State),
-			IsHashed:    state.IsHashed,
-			IsEncrypted: state.IsEncrypted,
-			Recipients:  state.Recipients,
-			States:      state.States,
-		})
+		JSON(smsgateway.GetMessageResponse(converters.MessageStateToDTO(*state)))
 }
 
 //	@Summary		Get messages
@@ -177,17 +171,18 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 //	@Security		JWTAuth
 //	@Tags			User, Messages
 //	@Produce		json
-//	@Param			from		query		string							false	"Start date in RFC3339 format"			Format(date-time)
-//	@Param			to			query		string							false	"End date in RFC3339 format"			Format(date-time)
-//	@Param			state		query		string							false	"Filter messages by processing state"	Enum(Pending, Processed, Sent, Delivered, Failed)
-//	@Param			deviceId	query		string							false	"Filter by device ID"					min(21)		max(21)
-//	@Param			limit		query		int								false	"Pagination limit"						default(50)	min(1)	max(100)
-//	@Param			offset		query		int								false	"Pagination offset"						default(0)
-//	@Success		200			{object}	smsgateway.GetMessagesResponse	"A list of messages"
-//	@Failure		400			{object}	smsgateway.ErrorResponse		"Invalid request"
-//	@Failure		401			{object}	smsgateway.ErrorResponse		"Unauthorized"
-//	@Failure		403			{object}	smsgateway.ErrorResponse		"Forbidden"
-//	@Failure		500			{object}	smsgateway.ErrorResponse		"Internal server error"
+//	@Param			from			query		string							false	"Start date in RFC3339 format"													Format(date-time)
+//	@Param			to				query		string							false	"End date in RFC3339 format"													Format(date-time)
+//	@Param			state			query		string							false	"Filter messages by processing state"											Enum(Pending, Processed, Sent, Delivered, Failed)
+//	@Param			deviceId		query		string							false	"Filter by device ID"															min(21)		max(21)
+//	@Param			limit			query		int								false	"Pagination limit"																default(50)	min(1)	max(100)
+//	@Param			offset			query		int								false	"Pagination offset"																default(0)
+//	@Param			includeContent	query		bool							false	"Include textMessage/dataMessage content for each message. Default is false"	default(false)
+//	@Success		200				{object}	smsgateway.GetMessagesResponse	"A list of messages"
+//	@Failure		400				{object}	smsgateway.ErrorResponse		"Invalid request"
+//	@Failure		401				{object}	smsgateway.ErrorResponse		"Unauthorized"
+//	@Failure		403				{object}	smsgateway.ErrorResponse		"Forbidden"
+//	@Failure		500				{object}	smsgateway.ErrorResponse		"Internal server error"
 //	@Router			/3rdparty/v1/messages [get]
 //
 // Get message history.

--- a/internal/sms-gateway/handlers/messages/mobile.go
+++ b/internal/sms-gateway/handlers/messages/mobile.go
@@ -97,7 +97,7 @@ func (h *MobileController) patch(device models.Device, c *fiber.Ctx) error {
 	}
 
 	for _, v := range req {
-		messageState := messages.MessageStateIn{
+		messageState := messages.MessageStateInput{
 			ID:         v.ID,
 			State:      messages.ProcessingState(v.State),
 			Recipients: v.Recipients,

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -13,12 +13,13 @@ type thirdPartyPostQueryParams struct {
 }
 
 type thirdPartyGetQueryParams struct {
-	StartDate string `query:"from"     validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
-	EndDate   string `query:"to"       validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
-	State     string `query:"state"    validate:"omitempty,oneof=Pending Processed Sent Delivered Failed"`
-	DeviceID  string `query:"deviceId" validate:"omitempty,len=21"`
-	Limit     int    `query:"limit"    validate:"omitempty,min=1,max=100"`
-	Offset    int    `query:"offset"   validate:"omitempty,min=0"`
+	StartDate      string `query:"from"           validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
+	EndDate        string `query:"to"             validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
+	State          string `query:"state"          validate:"omitempty,oneof=Pending Processed Sent Delivered Failed"`
+	DeviceID       string `query:"deviceId"       validate:"omitempty,len=21"`
+	Limit          int    `query:"limit"          validate:"omitempty,min=1,max=100"`
+	Offset         int    `query:"offset"         validate:"omitempty,min=0"`
+	IncludeContent bool   `query:"includeContent"`
 }
 
 func (p *thirdPartyGetQueryParams) Validate() error {
@@ -61,6 +62,7 @@ func (p *thirdPartyGetQueryParams) ToOptions() messages.SelectOptions {
 	var options messages.SelectOptions
 	options.WithRecipients = true
 	options.WithStates = true
+	options.WithContent = p.IncludeContent
 
 	if p.Limit > 0 {
 		options.Limit = min(p.Limit, maxLimit)

--- a/internal/sms-gateway/handlers/webhooks/3rdparty.go
+++ b/internal/sms-gateway/handlers/webhooks/3rdparty.go
@@ -101,8 +101,8 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 //	@Security		JWTAuth
 //	@Tags			User, Webhooks
 //	@Produce		json
-//	@Param			id	path		string						true	"Webhook ID"
-//	@Success		204	{object}	object						"Webhook deleted"
+//	@Param			id	path	string	true	"Webhook ID"
+//	@Success		204	"Successfully removed"
 //	@Failure		401	{object}	smsgateway.ErrorResponse	"Unauthorized"
 //	@Failure		403	{object}	smsgateway.ErrorResponse	"Forbidden"
 //	@Failure		500	{object}	smsgateway.ErrorResponse	"Internal server error"

--- a/internal/sms-gateway/modules/messages/cache.go
+++ b/internal/sms-gateway/modules/messages/cache.go
@@ -27,7 +27,7 @@ func newCache(config Config, storage cacheImpl.Cache) *cache {
 	}
 }
 
-func (c *cache) Set(ctx context.Context, userID, id string, message *MessageStateOut) error {
+func (c *cache) Set(ctx context.Context, userID, id string, message *MessageState) error {
 	var (
 		err  error
 		data []byte
@@ -50,7 +50,7 @@ func (c *cache) Set(ctx context.Context, userID, id string, message *MessageStat
 	return nil
 }
 
-func (c *cache) Get(ctx context.Context, userID, id string) (*MessageStateOut, error) {
+func (c *cache) Get(ctx context.Context, userID, id string) (*MessageState, error) {
 	ctx, cancel := context.WithTimeout(ctx, cacheTimeout)
 	defer cancel()
 
@@ -63,7 +63,7 @@ func (c *cache) Get(ctx context.Context, userID, id string) (*MessageStateOut, e
 		return nil, nil //nolint:nilnil //empty cached value is used for caching "Not Found"
 	}
 
-	message := new(MessageStateOut)
+	message := new(MessageState)
 	if jsonErr := json.Unmarshal(data, message); jsonErr != nil {
 		return nil, fmt.Errorf("failed to unmarshal message: %w", jsonErr)
 	}

--- a/internal/sms-gateway/modules/messages/converters.go
+++ b/internal/sms-gateway/modules/messages/converters.go
@@ -9,7 +9,7 @@ import (
 	"github.com/capcom6/go-helpers/slices"
 )
 
-func messageToDomain(input Message) (MessageOut, error) {
+func messageToDomain(input messageModel) (Message, error) {
 	var ttl *uint64
 	if input.ValidUntil != nil {
 		secondsUntil := uint64(math.Max(0, time.Until(*input.ValidUntil).Seconds()))
@@ -18,19 +18,21 @@ func messageToDomain(input Message) (MessageOut, error) {
 
 	textContent, err := input.GetTextContent()
 	if err != nil {
-		return MessageOut{}, fmt.Errorf("failed to get text content: %w", err)
+		return Message{}, fmt.Errorf("failed to get text content: %w", err)
 	}
 	dataContent, err := input.GetDataContent()
 	if err != nil {
-		return MessageOut{}, fmt.Errorf("failed to get data content: %w", err)
+		return Message{}, fmt.Errorf("failed to get data content: %w", err)
 	}
 
-	return MessageOut{
-		MessageIn: MessageIn{
-			ID: input.ExtID,
+	return Message{
+		MessageInput: MessageInput{
+			MessageContent: MessageContent{
+				TextContent: textContent,
+				DataContent: dataContent,
+			},
 
-			TextContent: textContent,
-			DataContent: dataContent,
+			ID: input.ExtID,
 
 			PhoneNumbers:       slices.Map(input.Recipients, recipientToDomain),
 			IsEncrypted:        input.IsEncrypted,
@@ -44,6 +46,6 @@ func messageToDomain(input Message) (MessageOut, error) {
 	}, nil
 }
 
-func recipientToDomain(input MessageRecipient) string {
+func recipientToDomain(input messageRecipientModel) string {
 	return input.PhoneNumber
 }

--- a/internal/sms-gateway/modules/messages/domain.go
+++ b/internal/sms-gateway/modules/messages/domain.go
@@ -6,11 +6,25 @@ import (
 	"github.com/android-sms-gateway/client-go/smsgateway"
 )
 
-type MessageIn struct {
-	ID string
+type TextMessageContent = smsgateway.TextMessage
+type DataMessageContent = smsgateway.DataMessage
+type HashedMessageContent = smsgateway.HashedMessage
 
-	TextContent *TextMessageContent
-	DataContent *DataMessageContent
+type MessageContent struct {
+	TextContent *TextMessageContent `json:"textContent,omitempty"`
+	DataContent *DataMessageContent `json:"dataContent,omitempty"`
+}
+
+type MessageStateContent struct {
+	MessageContent
+
+	HashedContent *HashedMessageContent `json:"hashedContent,omitempty"`
+}
+
+type MessageInput struct {
+	MessageContent
+
+	ID string
 
 	PhoneNumbers []string
 	IsEncrypted  bool
@@ -22,23 +36,24 @@ type MessageIn struct {
 	Priority           smsgateway.MessagePriority
 }
 
-type MessageOut struct {
-	MessageIn
+type Message struct {
+	MessageInput
 
 	CreatedAt time.Time
 }
 
-type MessageStateIn struct {
+type MessageStateInput struct {
 	ID         string                      `json:"id"`         // Message ID
 	State      ProcessingState             `json:"state"`      // State
 	Recipients []smsgateway.RecipientState `json:"recipients"` // Recipients states
 	States     map[string]time.Time        `json:"states"`     // History of states
 }
 
-type MessageStateOut struct {
-	MessageStateIn
+type MessageState struct {
+	MessageStateInput
+	MessageStateContent
 
-	DeviceID    string `json:"device_id"`    // Device ID
-	IsHashed    bool   `json:"is_hashed"`    // Hashed
-	IsEncrypted bool   `json:"is_encrypted"` // Encrypted
+	DeviceID    string `json:"deviceId"`    // Device ID
+	IsHashed    bool   `json:"isHashed"`    // Hashed
+	IsEncrypted bool   `json:"isEncrypted"` // Encrypted
 }

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/android-sms-gateway/client-go/smsgateway"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/models"
 	"github.com/samber/lo"
 	"gorm.io/gorm"
@@ -24,16 +25,7 @@ const (
 	MessageTypeData MessageType = "Data"
 )
 
-type TextMessageContent struct {
-	Text string `json:"text"`
-}
-
-type DataMessageContent struct {
-	Data string `json:"data"`
-	Port uint16 `json:"port"`
-}
-
-type Message struct {
+type messageModel struct {
 	models.SoftDeletableModel
 
 	ID                 uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
@@ -50,12 +42,12 @@ type Message struct {
 	IsHashed    bool `gorm:"not null;type:tinyint(1) unsigned;default:0"`
 	IsEncrypted bool `gorm:"not null;type:tinyint(1) unsigned;default:0"`
 
-	Device     models.Device      `gorm:"foreignKey:DeviceID;constraint:OnDelete:CASCADE"`
-	Recipients []MessageRecipient `gorm:"foreignKey:MessageID;constraint:OnDelete:CASCADE"`
-	States     []MessageState     `gorm:"foreignKey:MessageID;constraint:OnDelete:CASCADE"`
+	Device     models.Device           `gorm:"foreignKey:DeviceID;constraint:OnDelete:CASCADE"`
+	Recipients []messageRecipientModel `gorm:"foreignKey:MessageID;constraint:OnDelete:CASCADE"`
+	States     []messageStateModel     `gorm:"foreignKey:MessageID;constraint:OnDelete:CASCADE"`
 }
 
-func NewMessage(
+func newMessageModel(
 	extID string,
 	deviceID string,
 	phoneNumbers []string,
@@ -64,12 +56,12 @@ func NewMessage(
 	validUntil *time.Time,
 	withDeliveryReport bool,
 	isEncrypted bool,
-) *Message {
+) *messageModel {
 	//nolint:exhaustruct // partial constructor
-	return &Message{
+	return &messageModel{
 		ExtID:    extID,
 		DeviceID: deviceID,
-		Recipients: lo.Map(phoneNumbers, func(item string, _ int) MessageRecipient {
+		Recipients: lo.Map(phoneNumbers, func(item string, _ int) messageRecipientModel {
 			return newMessageRecipient(item, ProcessingStatePending, nil)
 		}),
 		Priority:           priority,
@@ -82,7 +74,11 @@ func NewMessage(
 	}
 }
 
-func (m *Message) SetTextContent(content TextMessageContent) error {
+func (*messageModel) TableName() string {
+	return "messages"
+}
+
+func (m *messageModel) SetTextContent(content TextMessageContent) error {
 	contentJSON, err := json.Marshal(content)
 	if err != nil {
 		return fmt.Errorf("failed to marshal: %w", err)
@@ -94,8 +90,8 @@ func (m *Message) SetTextContent(content TextMessageContent) error {
 	return nil
 }
 
-func (m *Message) GetTextContent() (*TextMessageContent, error) {
-	if m.Type != MessageTypeText {
+func (m *messageModel) GetTextContent() (*TextMessageContent, error) {
+	if m.Type != MessageTypeText || m.Content == "" || m.IsHashed {
 		return nil, nil //nolint:nilnil // special meaning
 	}
 
@@ -109,7 +105,7 @@ func (m *Message) GetTextContent() (*TextMessageContent, error) {
 	return content, nil
 }
 
-func (m *Message) SetDataContent(content DataMessageContent) error {
+func (m *messageModel) SetDataContent(content DataMessageContent) error {
 	contentJSON, err := json.Marshal(content)
 	if err != nil {
 		return fmt.Errorf("failed to marshal: %w", err)
@@ -121,8 +117,8 @@ func (m *Message) SetDataContent(content DataMessageContent) error {
 	return nil
 }
 
-func (m *Message) GetDataContent() (*DataMessageContent, error) {
-	if m.Type != MessageTypeData {
+func (m *messageModel) GetDataContent() (*DataMessageContent, error) {
+	if m.Type != MessageTypeData || m.Content == "" || m.IsHashed {
 		return nil, nil //nolint:nilnil // special meaning
 	}
 
@@ -136,7 +132,64 @@ func (m *Message) GetDataContent() (*DataMessageContent, error) {
 	return content, nil
 }
 
-type MessageRecipient struct {
+func (m *messageModel) GetHashedContent() (*HashedMessageContent, error) {
+	if !m.IsHashed || m.Content == "" {
+		return nil, nil //nolint:nilnil // special meaning
+	}
+
+	return &smsgateway.HashedMessage{
+		Hash: m.Content,
+	}, nil
+}
+
+func (m *messageModel) toStateDomain() (*MessageState, error) {
+	textContent, err := m.GetTextContent()
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode text content: %w", err)
+	}
+
+	dataContent, err := m.GetDataContent()
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode data content: %w", err)
+	}
+
+	hashedContent, err := m.GetHashedContent()
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode hashed content: %w", err)
+	}
+
+	content := MessageStateContent{
+		MessageContent: MessageContent{
+			TextContent: textContent,
+			DataContent: dataContent,
+		},
+		HashedContent: hashedContent,
+	}
+
+	return &MessageState{
+		MessageStateInput: MessageStateInput{
+			ID:    m.ExtID,
+			State: m.State,
+			Recipients: lo.Map(
+				m.Recipients,
+				func(item messageRecipientModel, _ int) smsgateway.RecipientState {
+					return item.toDomain()
+				},
+			),
+			States: lo.Associate(
+				m.States,
+				func(item messageStateModel) (string, time.Time) { return string(item.State), item.UpdatedAt },
+			),
+		},
+		MessageStateContent: content,
+
+		DeviceID:    m.DeviceID,
+		IsHashed:    m.IsHashed,
+		IsEncrypted: m.IsEncrypted,
+	}, nil
+}
+
+type messageRecipientModel struct {
 	ID          uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
 	MessageID   uint64          `gorm:"uniqueIndex:unq_message_recipients_message_id_phone_number,priority:1;type:BIGINT UNSIGNED"`
 	PhoneNumber string          `gorm:"uniqueIndex:unq_message_recipients_message_id_phone_number,priority:2;type:varchar(128)"`
@@ -144,8 +197,8 @@ type MessageRecipient struct {
 	Error       *string         `gorm:"type:varchar(256)"`
 }
 
-func newMessageRecipient(phoneNumber string, state ProcessingState, err *string) MessageRecipient {
-	return MessageRecipient{
+func newMessageRecipient(phoneNumber string, state ProcessingState, err *string) messageRecipientModel {
+	return messageRecipientModel{
 		ID:          0,
 		MessageID:   0,
 		PhoneNumber: phoneNumber,
@@ -154,15 +207,31 @@ func newMessageRecipient(phoneNumber string, state ProcessingState, err *string)
 	}
 }
 
-type MessageState struct {
+func (m *messageRecipientModel) TableName() string {
+	return "message_recipients"
+}
+
+func (m *messageRecipientModel) toDomain() smsgateway.RecipientState {
+	return smsgateway.RecipientState{
+		PhoneNumber: m.PhoneNumber,
+		State:       smsgateway.ProcessingState(m.State),
+		Error:       m.Error,
+	}
+}
+
+type messageStateModel struct {
 	ID        uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
 	MessageID uint64          `gorm:"not null;type:BIGINT UNSIGNED;uniqueIndex:unq_message_states_message_id_state,priority:1"`
 	State     ProcessingState `gorm:"not null;type:enum('Pending','Sent','Processed','Delivered','Failed');uniqueIndex:unq_message_states_message_id_state,priority:2"`
 	UpdatedAt time.Time       `gorm:"<-:create;not null;autoupdatetime:false"`
 }
 
+func (m *messageStateModel) TableName() string {
+	return "message_states"
+}
+
 func Migrate(db *gorm.DB) error {
-	if err := db.AutoMigrate(new(Message), new(MessageRecipient), new(MessageState)); err != nil {
+	if err := db.AutoMigrate(new(messageModel), new(messageRecipientModel), new(messageStateModel)); err != nil {
 		return fmt.Errorf("messages migration failed: %w", err)
 	}
 	return nil

--- a/internal/sms-gateway/modules/messages/repository.go
+++ b/internal/sms-gateway/modules/messages/repository.go
@@ -27,8 +27,8 @@ func NewRepository(db *gorm.DB) *Repository {
 	}
 }
 
-func (r *Repository) Select(filter SelectFilter, options SelectOptions) ([]Message, int64, error) {
-	query := r.db.Model((*Message)(nil))
+func (r *Repository) list(filter SelectFilter, options SelectOptions) ([]messageModel, int64, error) {
+	query := r.db.Model((*messageModel)(nil))
 
 	// Apply date range filter
 	if !filter.StartDate.IsZero() {
@@ -92,7 +92,12 @@ func (r *Repository) Select(filter SelectFilter, options SelectOptions) ([]Messa
 		query = query.Preload("States")
 	}
 
-	messages := make([]Message, 0, min(options.Limit, int(total)))
+	// Apply content filter
+	if !options.WithContent {
+		query = query.Omit("Content")
+	}
+
+	messages := make([]messageModel, 0, min(options.Limit, int(total)))
 	if err := query.Find(&messages).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to select messages: %w", err)
 	}
@@ -100,33 +105,33 @@ func (r *Repository) Select(filter SelectFilter, options SelectOptions) ([]Messa
 	return messages, total, nil
 }
 
-func (r *Repository) SelectPending(deviceID string, order Order) ([]Message, error) {
-	messages, _, err := r.Select(
+func (r *Repository) listPending(deviceID string, order Order) ([]messageModel, error) {
+	messages, _, err := r.list(
 		*new(SelectFilter).WithDeviceID(deviceID).WithState(ProcessingStatePending),
-		*new(SelectOptions).IncludeRecipients().WithLimit(maxPendingBatch).WithOrderBy(order),
+		*new(SelectOptions).IncludeContent().IncludeRecipients().WithLimit(maxPendingBatch).WithOrderBy(order),
 	)
 
 	return messages, err
 }
 
-func (r *Repository) Get(filter SelectFilter, options SelectOptions) (Message, error) {
-	messages, _, err := r.Select(filter, options)
+func (r *Repository) get(filter SelectFilter, options SelectOptions) (messageModel, error) {
+	messages, _, err := r.list(filter, options)
 	if err != nil {
-		return Message{}, fmt.Errorf("failed to get message: %w", err)
+		return messageModel{}, fmt.Errorf("failed to get message: %w", err)
 	}
 
 	if len(messages) == 0 {
-		return Message{}, ErrMessageNotFound
+		return messageModel{}, ErrMessageNotFound
 	}
 
 	if len(messages) > 1 {
-		return Message{}, ErrMultipleMessagesFound
+		return messageModel{}, ErrMultipleMessagesFound
 	}
 
 	return messages[0], nil
 }
 
-func (r *Repository) Insert(message *Message) error {
+func (r *Repository) Insert(message *messageModel) error {
 	err := r.db.Omit("Device").Create(message).Error
 	if err == nil {
 		return nil
@@ -139,7 +144,7 @@ func (r *Repository) Insert(message *Message) error {
 	return fmt.Errorf("failed to insert message: %w", err)
 }
 
-func (r *Repository) UpdateState(message *Message) error {
+func (r *Repository) UpdateState(message *messageModel) error {
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(message).Select("State").Updates(message).Error; err != nil {
 			return err
@@ -155,7 +160,7 @@ func (r *Repository) UpdateState(message *Message) error {
 		}
 
 		for _, v := range message.Recipients {
-			if err := tx.Model((*MessageRecipient)(nil)).
+			if err := tx.Model((*messageRecipientModel)(nil)).
 				Where("message_id = ? AND phone_number = ?", message.ID, v.PhoneNumber).
 				Select("state", "error").
 				Updates(map[string]any{"state": v.State, "error": v.Error}).Error; err != nil {
@@ -197,6 +202,6 @@ func (r *Repository) Cleanup(ctx context.Context, until time.Time) (int64, error
 		WithContext(ctx).
 		Where("state <> ?", ProcessingStatePending).
 		Where("created_at < ?", until).
-		Delete(new(Message))
+		Delete(new(messageModel))
 	return res.RowsAffected, res.Error
 }

--- a/internal/sms-gateway/modules/messages/repository_filter.go
+++ b/internal/sms-gateway/modules/messages/repository_filter.go
@@ -52,6 +52,7 @@ type SelectOptions struct {
 	WithRecipients bool
 	WithDevice     bool
 	WithStates     bool
+	WithContent    bool
 
 	// OrderBy sets the retrieval order for pending messages.
 	// Empty (zero) value defaults to "lifo".
@@ -88,5 +89,10 @@ func (o *SelectOptions) IncludeDevice() *SelectOptions {
 
 func (o *SelectOptions) IncludeStates() *SelectOptions {
 	o.WithStates = true
+	return o
+}
+
+func (o *SelectOptions) IncludeContent() *SelectOptions {
+	o.WithContent = true
 	return o
 }

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -68,12 +68,12 @@ func (s *Service) RunBackgroundTasks(ctx context.Context, wg *sync.WaitGroup) {
 	})
 }
 
-func (s *Service) SelectPending(deviceID string, order Order) ([]MessageOut, error) {
+func (s *Service) SelectPending(deviceID string, order Order) ([]Message, error) {
 	if order == "" {
 		order = MessagesOrderLIFO
 	}
 
-	messages, err := s.messages.SelectPending(deviceID, order)
+	messages, err := s.messages.listPending(deviceID, order)
 	if err != nil {
 		return nil, err
 	}
@@ -81,10 +81,10 @@ func (s *Service) SelectPending(deviceID string, order Order) ([]MessageOut, err
 	return slices.MapOrError(messages, messageToDomain) //nolint:wrapcheck // already wrapped
 }
 
-func (s *Service) UpdateState(device *models.Device, message MessageStateIn) error {
-	existing, err := s.messages.Get(
+func (s *Service) UpdateState(device *models.Device, message MessageStateInput) error {
+	existing, err := s.messages.get(
 		*new(SelectFilter).WithExtID(message.ID).WithDeviceID(device.ID),
-		SelectOptions{}, //nolint:exhaustruct // not needed
+		*new(SelectOptions).IncludeContent(),
 	)
 	if err != nil {
 		return err
@@ -97,8 +97,8 @@ func (s *Service) UpdateState(device *models.Device, message MessageStateIn) err
 	existing.State = message.State
 	existing.States = lo.MapToSlice(
 		message.States,
-		func(key string, value time.Time) MessageState {
-			return MessageState{
+		func(key string, value time.Time) messageStateModel {
+			return messageStateModel{
 				ID:        0,
 				MessageID: existing.ID,
 				State:     ProcessingState(key),
@@ -112,11 +112,16 @@ func (s *Service) UpdateState(device *models.Device, message MessageStateIn) err
 		return updErr
 	}
 
+	state, err := existing.toStateDomain()
+	if err != nil {
+		return err
+	}
+
 	if cacheErr := s.cache.Set(
 		context.Background(),
 		device.UserID,
 		existing.ExtID,
-		anys.AsPointer(modelToMessageState(existing)),
+		state,
 	); cacheErr != nil {
 		s.logger.Warn("failed to cache message", zap.String("id", existing.ExtID), zap.Error(cacheErr))
 	}
@@ -130,33 +135,43 @@ func (s *Service) SelectStates(
 	userID string,
 	filter SelectFilter,
 	options SelectOptions,
-) ([]MessageStateOut, int64, error) {
+) ([]MessageState, int64, error) {
 	filter.UserID = userID
 
-	messages, total, err := s.messages.Select(filter, options)
+	messages, total, err := s.messages.list(filter, options)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to select messages: %w", err)
 	}
 
-	return slices.Map(messages, modelToMessageState), total, nil
+	result, err := slices.MapOrError(
+		messages,
+		func(m messageModel) (*MessageState, error) {
+			return m.toStateDomain()
+		},
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to map messages: %w", err)
+	}
+
+	return lo.FromSlicePtr(result), total, nil
 }
 
-func (s *Service) GetState(userID string, id string) (*MessageStateOut, error) {
-	dto, err := s.cache.Get(context.Background(), userID, id)
+func (s *Service) GetState(userID string, id string) (*MessageState, error) {
+	state, err := s.cache.Get(context.Background(), userID, id)
 	if err == nil {
 		s.metrics.IncCache(true)
 
 		// Cache nil entries represent "not found" and prevent repeated lookups
-		if dto == nil {
+		if state == nil {
 			return nil, ErrMessageNotFound
 		}
-		return dto, nil
+		return state, nil
 	}
 	s.metrics.IncCache(false)
 
-	message, err := s.messages.Get(
+	message, err := s.messages.get(
 		*new(SelectFilter).WithExtID(id).WithUserID(userID),
-		*new(SelectOptions).IncludeRecipients().IncludeDevice().IncludeStates(),
+		*new(SelectOptions).IncludeRecipients().IncludeDevice().IncludeStates().IncludeContent(),
 	)
 	if err != nil {
 		if errors.Is(err, ErrMessageNotFound) {
@@ -168,33 +183,27 @@ func (s *Service) GetState(userID string, id string) (*MessageStateOut, error) {
 		return nil, err
 	}
 
-	dto = anys.AsPointer(modelToMessageState(message))
-	if cacheErr := s.cache.Set(context.Background(), userID, id, dto); cacheErr != nil {
+	state, err = message.toStateDomain()
+	if err != nil {
+		return nil, err
+	}
+
+	if cacheErr := s.cache.Set(context.Background(), userID, id, state); cacheErr != nil {
 		s.logger.Warn("failed to cache message", zap.String("id", id), zap.Error(cacheErr))
 	}
 
-	return dto, nil
+	return state, nil
 }
 
-func (s *Service) Enqueue(device models.Device, message MessageIn, opts EnqueueOptions) (*MessageStateOut, error) {
+func (s *Service) Enqueue(device models.Device, message MessageInput, opts EnqueueOptions) (*MessageState, error) {
 	msg, err := s.prepareMessage(device, message, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	state := &MessageStateOut{
-		DeviceID: device.ID,
-		MessageStateIn: MessageStateIn{
-			ID:    msg.ExtID,
-			State: ProcessingStatePending,
-			Recipients: lo.Map(
-				msg.Recipients,
-				func(item MessageRecipient, _ int) smsgateway.RecipientState { return modelToRecipientState(item) },
-			),
-			States: map[string]time.Time{},
-		},
-		IsHashed:    false,
-		IsEncrypted: msg.IsEncrypted,
+	state, err := msg.toStateDomain()
+	if err != nil {
+		return nil, err
 	}
 
 	if insErr := s.messages.Insert(msg); insErr != nil {
@@ -205,7 +214,7 @@ func (s *Service) Enqueue(device models.Device, message MessageIn, opts EnqueueO
 		context.Background(),
 		device.UserID,
 		msg.ExtID,
-		anys.AsPointer(modelToMessageState(*msg)),
+		state,
 	); cacheErr != nil {
 		s.logger.Warn("failed to cache message", zap.String("id", msg.ExtID), zap.Error(cacheErr))
 	}
@@ -225,7 +234,11 @@ func (s *Service) Enqueue(device models.Device, message MessageIn, opts EnqueueO
 	return state, nil
 }
 
-func (s *Service) prepareMessage(device models.Device, message MessageIn, opts EnqueueOptions) (*Message, error) {
+func (s *Service) prepareMessage(
+	device models.Device,
+	message MessageInput,
+	opts EnqueueOptions,
+) (*messageModel, error) {
 	var phone string
 	var err error
 	for i, v := range message.PhoneNumbers {
@@ -248,7 +261,7 @@ func (s *Service) prepareMessage(device models.Device, message MessageIn, opts E
 		)
 	}
 
-	msg := NewMessage(
+	msg := newMessageModel(
 		message.ID,
 		device.ID,
 		message.PhoneNumbers,
@@ -291,8 +304,8 @@ func (s *Service) ExportInbox(device models.Device, since, until time.Time) erro
 
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Service) recipientsStateToModel(input []smsgateway.RecipientState, hash bool) []MessageRecipient {
-	output := make([]MessageRecipient, len(input))
+func (s *Service) recipientsStateToModel(input []smsgateway.RecipientState, hash bool) []messageRecipientModel {
+	output := make([]messageRecipientModel, len(input))
 
 	for i, v := range input {
 		phoneNumber := v.PhoneNumber
@@ -317,33 +330,6 @@ func (s *Service) recipientsStateToModel(input []smsgateway.RecipientState, hash
 	}
 
 	return output
-}
-
-func modelToMessageState(input Message) MessageStateOut {
-	return MessageStateOut{
-		DeviceID:    input.DeviceID,
-		IsHashed:    input.IsHashed,
-		IsEncrypted: input.IsEncrypted,
-
-		MessageStateIn: MessageStateIn{
-			ID:         input.ExtID,
-			State:      input.State,
-			Recipients: slices.Map(input.Recipients, modelToRecipientState),
-			States: slices.Associate(
-				input.States,
-				func(state MessageState) string { return string(state.State) },
-				func(state MessageState) time.Time { return state.UpdatedAt },
-			),
-		},
-	}
-}
-
-func modelToRecipientState(input MessageRecipient) smsgateway.RecipientState {
-	return smsgateway.RecipientState{
-		PhoneNumber: input.PhoneNumber,
-		State:       smsgateway.ProcessingState(input.State),
-		Error:       input.Error,
-	}
 }
 
 func cleanPhoneNumber(input string) (string, error) {

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -483,6 +483,13 @@ const docTemplate = `{
                         "description": "Pagination offset",
                         "name": "offset",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Include textMessage/dataMessage content for each message. Default is false",
+                        "name": "includeContent",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1064,10 +1071,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "Webhook deleted",
-                        "schema": {
-                            "type": "object"
-                        }
+                        "description": "Successfully removed"
                     },
                     "401": {
                         "description": "Unauthorized",
@@ -1308,11 +1312,27 @@ const docTemplate = `{
                 "state"
             ],
             "properties": {
+                "dataMessage": {
+                    "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is data.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.DataMessage"
+                        }
+                    ]
+                },
                 "deviceId": {
                     "description": "Device ID",
                     "type": "string",
                     "maxLength": 21,
                     "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
+                "hashedMessage": {
+                    "description": "Hashed message content, if isHashed is true",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.HashedMessage"
+                        }
+                    ]
                 },
                 "id": {
                     "description": "Message ID",
@@ -1353,6 +1373,26 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "textMessage": {
+                    "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is text.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.TextMessage"
+                        }
+                    ]
+                }
+            }
+        },
+        "smsgateway.HashedMessage": {
+            "type": "object",
+            "required": [
+                "hash"
+            ],
+            "properties": {
+                "hash": {
+                    "type": "string",
+                    "example": "1d4b6e3b1b6e3b1b6e3b1b6e3b1b6e3b1b6e3b1b"
                 }
             }
         },
@@ -1454,7 +1494,8 @@ const docTemplate = `{
                 },
                 "createdAt": {
                     "description": "The timestamp when this log entry was created.",
-                    "type": "string"
+                    "type": "string",
+                    "format": "date-time"
                 },
                 "id": {
                     "description": "A unique identifier for the log entry.",
@@ -1621,11 +1662,27 @@ const docTemplate = `{
                 "state"
             ],
             "properties": {
+                "dataMessage": {
+                    "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is data.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.DataMessage"
+                        }
+                    ]
+                },
                 "deviceId": {
                     "description": "Device ID",
                     "type": "string",
                     "maxLength": 21,
                     "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
+                "hashedMessage": {
+                    "description": "Hashed message content, if isHashed is true",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.HashedMessage"
+                        }
+                    ]
                 },
                 "id": {
                     "description": "Message ID",
@@ -1666,6 +1723,14 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "textMessage": {
+                    "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is text.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.TextMessage"
+                        }
+                    ]
                 }
             }
         },


### PR DESCRIPTION
### Motivation

- Provide an option to include text/data content with message list results to avoid additional per-message fetches and reduce client round-trips.
- Extend the messages listing API and OpenAPI docs to surface the new `includeContent` query parameter and a richer response schema.

### Description

- Add `MessageWithStateOut` to the messages domain and implement `modelToMessageWithState` to decode text and data content from stored messages.
- Add `SelectWithContent` to `Service` to return messages with decoded content and map repository models to `MessageWithStateOut` using `slices.MapOrError`.
- Introduce `converters.MessageListItemDTO` and `MessageListItemToDTO` to represent and build list items that optionally include `textMessage` and `dataMessage` fields.
- Update the third-party messages controller to accept a new `includeContent` query param (`thirdPartyGetQueryParams.IncludeContent`) and to branch between `SelectWithContent` (when true) and `SelectStates` (when false), returning the appropriate DTOs and setting `X-Total-Count`.
- Add `GetMessagesResponse` alias type for the new response shape and update OpenAPI `docs.go` to document the `includeContent` param and the `converters.MessageListItemDTO` response schema.
- Add unit tests for `MessageListItemToDTO` and extend existing message converter tests to cover the new behavior.

### Testing

- Ran unit tests for converters with `go test ./internal/sms-gateway/handlers/converters -run TestMessageListItemToDTO` and the new test passed.
- Ran package tests affected by the change with `go test ./...` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf2239b7d0832c89f0a6c2442e9521)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added includeContent query param to message listing to optionally return per-message text, data, and hashed content; responses include textMessage, dataMessage, and hashedMessage when requested.
* **Documentation**
  * OpenAPI and example request files updated to show includeContent usage, new hashedMessage schema, adjusted webhook 204 text, and a named enqueue→fetch flow; message endpoints in examples moved to /messages and some requests now use Basic auth.
* **Chores**
  * Development start target now checks for tool availability and sets TZ/DEBUG before launching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->