### PR TITLE
[messages] add `scheduleAt` field support

### DIFF
--- a/api/local.http
+++ b/api/local.http
@@ -87,6 +87,21 @@ Authorization: Basic {{localCredentials}}
 }
 
 ###
+# Scheduled message - will be sent at the specified time
+POST {{localUrl}}/messages HTTP/1.1
+Content-Type: application/json
+Authorization: Basic {{localCredentials}}
+
+{
+    "message": "Scheduled message test #3",
+    "scheduleAt": "2026-04-26T02:00:00Z",
+    "phoneNumbers": [
+        "{{phone}}"
+    ],
+    "withDeliveryReport": true
+}
+
+###
 GET {{localUrl}}/messages HTTP/1.1
 Authorization: Basic {{localCredentials}}
 

--- a/api/requests.http
+++ b/api/requests.http
@@ -17,6 +17,23 @@ GET {{baseUrl}}/3rdparty/v1/health/ready HTTP/1.1
 GET {{baseUrl}}/3rdparty/v1/health/live HTTP/1.1
 
 ###
+# Schedule a message for future delivery
+POST {{baseUrl}}/3rdparty/v1/messages HTTP/1.1
+Content-Type: application/json
+Authorization: Basic {{credentials}}
+
+{
+    "message": "This message is scheduled for the future",
+    "scheduleAt": "2027-04-11T04:30:00Z",
+    "phoneNumbers": [
+        "{{phone}}"
+    ],
+    "withDeliveryReport": true,
+    "priority": 0,
+    "simNumber": 1
+}
+
+###
 POST {{baseUrl}}/3rdparty/v1/messages?skipPhoneValidation=false&deviceActiveWithin=240 HTTP/1.1
 Content-Type: application/json
 Authorization: Basic {{credentials}}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	firebase.google.com/go/v4 v4.19.0
-	github.com/android-sms-gateway/client-go v1.12.4
+	github.com/android-sms-gateway/client-go v1.12.5
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/capcom6/go-helpers v0.3.0
 	github.com/capcom6/go-infra-fx v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/android-sms-gateway/client-go v1.12.4 h1:umYoIEFQQHFOC4RvqTGorzScicYwzuyRP5Ep6sGwSHs=
-github.com/android-sms-gateway/client-go v1.12.4/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.12.5 h1:LcfTIvtRxOujPxmtFfCjHuFiX5wFyjN9yqGE+82jZdw=
+github.com/android-sms-gateway/client-go v1.12.5/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=

--- a/internal/sms-gateway/handlers/converters/messages.go
+++ b/internal/sms-gateway/handlers/converters/messages.go
@@ -37,6 +37,7 @@ func MessageToMobileDTO(m messages.Message) smsgateway.MobileMessage {
 			PhoneNumbers:       m.PhoneNumbers,
 			TTL:                m.TTL,
 			ValidUntil:         m.ValidUntil,
+			ScheduleAt:         m.ScheduleAt,
 			Priority:           m.Priority,
 		},
 		CreatedAt: m.CreatedAt,

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -134,6 +134,7 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 		WithDeliveryReport: req.WithDeliveryReport,
 		TTL:                req.TTL,
 		ValidUntil:         req.ValidUntil,
+		ScheduleAt:         req.ScheduleAt,
 		Priority:           req.Priority,
 	}
 	state, err := h.messagesSvc.Enqueue(

--- a/internal/sms-gateway/models/migrations/mysql/20260411000000_add_messages_scheduled_at.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260411000000_add_messages_scheduled_at.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `messages`
+ADD `schedule_at` datetime NULL DEFAULT NULL;
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE `messages` DROP `schedule_at`;
+-- +goose StatementEnd

--- a/internal/sms-gateway/modules/messages/converters.go
+++ b/internal/sms-gateway/modules/messages/converters.go
@@ -40,6 +40,7 @@ func messageToDomain(input messageModel) (Message, error) {
 			WithDeliveryReport: &input.WithDeliveryReport,
 			TTL:                ttl,
 			ValidUntil:         input.ValidUntil,
+			ScheduleAt:         input.ScheduleAt,
 			Priority:           smsgateway.MessagePriority(input.Priority),
 		},
 		CreatedAt: input.CreatedAt,

--- a/internal/sms-gateway/modules/messages/domain.go
+++ b/internal/sms-gateway/modules/messages/domain.go
@@ -33,6 +33,7 @@ type MessageInput struct {
 	WithDeliveryReport *bool
 	TTL                *uint64
 	ValidUntil         *time.Time
+	ScheduleAt         *time.Time
 	Priority           smsgateway.MessagePriority
 }
 

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -35,6 +35,7 @@ type messageModel struct {
 	Content            string          `gorm:"not null;type:text"`
 	State              ProcessingState `gorm:"not null;type:enum('Pending','Sent','Processed','Delivered','Failed');default:Pending;index:idx_messages_device_state"`
 	ValidUntil         *time.Time      `gorm:"type:datetime"`
+	ScheduleAt         *time.Time      `gorm:"type:datetime"`
 	SimNumber          *uint8          `gorm:"type:tinyint(1) unsigned"`
 	WithDeliveryReport bool            `gorm:"not null;type:tinyint(1) unsigned"`
 	Priority           int8            `gorm:"not null;type:tinyint;default:0"`
@@ -54,6 +55,7 @@ func newMessageModel(
 	priority int8,
 	simNumber *uint8,
 	validUntil *time.Time,
+	scheduleAt *time.Time,
 	withDeliveryReport bool,
 	isEncrypted bool,
 ) *messageModel {
@@ -67,6 +69,7 @@ func newMessageModel(
 		Priority:           priority,
 		SimNumber:          simNumber,
 		ValidUntil:         validUntil,
+		ScheduleAt:         scheduleAt,
 		WithDeliveryReport: withDeliveryReport,
 		IsEncrypted:        isEncrypted,
 

--- a/internal/sms-gateway/modules/messages/repository.go
+++ b/internal/sms-gateway/modules/messages/repository.go
@@ -76,9 +76,9 @@ func (r *Repository) list(filter SelectFilter, options SelectOptions) ([]message
 
 	// Apply ordering
 	if options.OrderBy == MessagesOrderFIFO {
-		query = query.Order("messages.priority DESC, messages.id ASC")
+		query = query.Order("messages.schedule_at ASC, messages.priority DESC, messages.id ASC")
 	} else {
-		query = query.Order("messages.priority DESC, messages.id DESC")
+		query = query.Order("messages.schedule_at ASC, messages.priority DESC, messages.id DESC")
 	}
 
 	// Preload related data

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -261,6 +261,10 @@ func (s *Service) prepareMessage(
 		)
 	}
 
+	if message.ScheduleAt != nil && validUntil != nil && message.ScheduleAt.After(*validUntil) {
+		return nil, ValidationError("scheduleAt must be less than or equal to validUntil")
+	}
+
 	msg := newMessageModel(
 		message.ID,
 		device.ID,
@@ -268,6 +272,7 @@ func (s *Service) prepareMessage(
 		int8(message.Priority),
 		message.SimNumber,
 		validUntil,
+		message.ScheduleAt,
 		anys.OrDefault(message.WithDeliveryReport, true),
 		message.IsEncrypted,
 	)

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -1872,6 +1872,12 @@ const docTemplate = `{
                     ],
                     "example": 0
                 },
+                "scheduleAt": {
+                    "description": "Schedule message delivery at (must be in the future)",
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2020-01-01T08:30:00Z"
+                },
                 "simNumber": {
                     "description": "SIM card number (1-3), if not set - default SIM will be used",
                     "type": "integer",
@@ -1896,6 +1902,7 @@ const docTemplate = `{
                 "validUntil": {
                     "description": "Valid until (conflicts with ` + "`" + `TTL` + "`" + `)",
                     "type": "string",
+                    "format": "date-time",
                     "example": "2020-01-01T00:00:00Z"
                 },
                 "withDeliveryReport": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule SMS messages for future delivery via the third-party and local send endpoints; scheduled messages are accepted and enqueued.

* **Validation & Reliability**
  * Scheduling must be on or before the message valid-until timestamp.
  * Message listing/queueing now prioritizes scheduled time when ordering.

* **Documentation**
  * API docs and examples include a scheduleAt date-time field and usage examples with auth.

* **Chores**
  * Database migration added to store scheduled timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->