### PR TITLE
[inbox] add refresh options

### DIFF
--- a/api/requests.http
+++ b/api/requests.http
@@ -128,6 +128,8 @@ Content-Type: application/json
 }
 
 ###
+# @name getDevices
+@deviceId={{getDevices.response.body.$.0.id}}
 GET {{baseUrl}}/3rdparty/v1/devices HTTP/1.1
 Authorization: Basic {{credentials}}
 # Authorization: Bearer {{jwtToken}}
@@ -252,6 +254,28 @@ Authorization: Bearer {{refreshToken}}
 DELETE {{baseUrl}}/3rdparty/v1/auth/token/{{jti}} HTTP/1.1
 Authorization: Basic {{credentials}}
 Content-Type: application/json
+
+###
+# @name getInbox
+@inboxMessageId={{getInbox.response.body.$.0.id}}
+GET {{baseUrl}}/3rdparty/v1/inbox HTTP/1.1
+Authorization: Basic {{credentials}}
+
+###
+GET {{baseUrl}}/3rdparty/v1/inbox?type=SMS&limit=1&offset={{$randomInt 0 100}}&from=2026-01-01T00:00:00.000Z&to=2026-12-31T23:59:59Z HTTP/1.1
+Authorization: Basic {{credentials}}
+
+###
+POST {{baseUrl}}/3rdparty/v1/inbox/refresh HTTP/1.1
+Authorization: Basic {{credentials}}
+Content-Type: application/json
+
+{
+    "deviceId": "{{deviceId}}",
+    "since": "2026-01-01T00:00:00.000Z",
+    "until": "2026-12-31T23:59:59Z",
+    "messageTypes": ["SMS", "MMS"]
+}
 
 ###
 GET http://localhost:3000/metrics HTTP/1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	firebase.google.com/go/v4 v4.19.0
-	github.com/android-sms-gateway/client-go v1.12.5
+	github.com/android-sms-gateway/client-go v1.12.9-0.20260519005959-eae21b02f80f
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/capcom6/go-helpers v0.3.0
 	github.com/capcom6/go-infra-fx v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/android-sms-gateway/client-go v1.12.5 h1:LcfTIvtRxOujPxmtFfCjHuFiX5wFyjN9yqGE+82jZdw=
-github.com/android-sms-gateway/client-go v1.12.5/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.12.9-0.20260519005959-eae21b02f80f h1:NdX7nE17ObbkQcVyJPeAsZ9kvVtCbHu0hdB4/12UkqM=
+github.com/android-sms-gateway/client-go v1.12.9-0.20260519005959-eae21b02f80f/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=

--- a/internal/sms-gateway/handlers/inbox/3rdparty.go
+++ b/internal/sms-gateway/handlers/inbox/3rdparty.go
@@ -1,6 +1,7 @@
 package inbox
 
 import (
+	"github.com/android-sms-gateway/client-go/smsgateway"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/base"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/middlewares/permissions"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/middlewares/userauth"
@@ -63,22 +64,37 @@ func (h *ThirdPartyController) list(_ string, _ *fiber.Ctx) error {
 }
 
 //	@Summary		Request inbox messages refresh
-//	@Description	Refreshes inbox messages. Webhooks will not be triggered.
+//	@Description	Refreshes inbox messages. Webhooks are triggered when triggerWebhooks is true.
 //	@Security		ApiAuth
 //	@Security		JWTAuth
 //	@Tags			User, Inbox
 //	@Accept			json
 //	@Produce		json
-//	@Param			request	body		smsgateway.MessagesExportRequest	true	"Export inbox request"
-//	@Success		202		{object}	object								"Inbox refresh request accepted"
-//	@Failure		400		{object}	smsgateway.ErrorResponse			"Invalid request"
-//	@Failure		401		{object}	smsgateway.ErrorResponse			"Unauthorized"
-//	@Failure		403		{object}	smsgateway.ErrorResponse			"Forbidden"
-//	@Failure		500		{object}	smsgateway.ErrorResponse			"Internal server error"
-//	@Failure		501		{object}	smsgateway.ErrorResponse			"Not implemented"
+//	@Param			request	body	smsgateway.InboxRefreshRequest	true	"Refresh inbox request"
+//	@Success		202		"Inbox refresh request accepted"
+//	@Failure		400		{object}	smsgateway.ErrorResponse	"Invalid request"
+//	@Failure		401		{object}	smsgateway.ErrorResponse	"Unauthorized"
+//	@Failure		403		{object}	smsgateway.ErrorResponse	"Forbidden"
+//	@Failure		500		{object}	smsgateway.ErrorResponse	"Internal server error"
 //	@Router			/3rdparty/v1/inbox/refresh [post]
 //
 // Request inbox refresh.
-func (h *ThirdPartyController) refresh(_ string, _ *fiber.Ctx) error {
-	return fiber.NewError(fiber.StatusNotImplemented, "Inbox API is not implemented yet")
+func (h *ThirdPartyController) refresh(userID string, c *fiber.Ctx) error {
+	req := new(smsgateway.InboxRefreshRequest)
+	if err := h.BodyParserValidator(c, req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	if err := h.inboxSvc.Refresh(
+		userID,
+		req.DeviceID,
+		req.Since,
+		req.Until,
+		req.MessageTypes,
+		&req.TriggerWebhooks,
+	); err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	}
+
+	return c.SendStatus(fiber.StatusAccepted)
 }

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -17,6 +17,7 @@ import (
 	"github.com/capcom6/go-helpers/slices"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
+	"github.com/samber/lo"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )
@@ -244,32 +245,27 @@ func (h *ThirdPartyController) get(userID string, c *fiber.Ctx) error {
 	return c.JSON(converters.MessageStateToDTO(*state))
 }
 
-//	@Summary		Request inbox messages export
-//	@Description	Initiates process of inbox messages export via webhooks. For each message the `sms:received` webhook will be triggered. The webhooks will be triggered without specific order.
-//	@Security		ApiAuth
-//	@Security		JWTAuth
-//	@Tags			User, Messages
-//	@Accept			json
-//	@Produce		json
-//	@Param			request	body		smsgateway.MessagesExportRequest	true	"Export inbox request"
-//	@Success		202		{object}	object								"Inbox export request accepted"
-//	@Failure		400		{object}	smsgateway.ErrorResponse			"Invalid request"
-//	@Failure		401		{object}	smsgateway.ErrorResponse			"Unauthorized"
-//	@Failure		403		{object}	smsgateway.ErrorResponse			"Forbidden"
-//	@Failure		500		{object}	smsgateway.ErrorResponse			"Internal server error"
-//	@Router			/3rdparty/v1/messages/inbox/export [post]
-//
 // Export inbox.
+//
+// Deprecated: use /3rdparty/v1/inbox/refresh instead.
 func (h *ThirdPartyController) postInboxExport(userID string, c *fiber.Ctx) error {
 	req := new(smsgateway.MessagesExportRequest)
 	if err := h.BodyParserValidator(c, req); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
-	if err := h.inboxSvc.Refresh(userID, &req.DeviceID, req.Since, req.Until); err != nil {
-		return fmt.Errorf("failed to refresh inbox: %w", err)
+	if err := h.inboxSvc.Refresh(
+		userID,
+		&req.DeviceID,
+		req.Since,
+		req.Until,
+		[]smsgateway.IncomingMessageType{smsgateway.IncomingMessageTypeSMS},
+		lo.ToPtr(true),
+	); err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}
 
+	c.Set("Deprecation", "true")
 	return c.SendStatus(fiber.StatusAccepted)
 }
 

--- a/internal/sms-gateway/inbox/service.go
+++ b/internal/sms-gateway/inbox/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/android-sms-gateway/client-go/smsgateway"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/events"
 	"go.uber.org/zap"
 )
@@ -22,8 +23,14 @@ func New(eventsSvc *events.Service, logger *zap.Logger) *Service {
 	}
 }
 
-func (s *Service) Refresh(userID string, deviceID *string, since, until time.Time) error {
-	event := events.NewMessagesExportRequestedEvent(since, until)
+func (s *Service) Refresh(
+	userID string,
+	deviceID *string,
+	since, until time.Time,
+	types []smsgateway.IncomingMessageType,
+	triggerWebhooks *bool,
+) error {
+	event := events.NewMessagesExportRequestedEvent(since, until, types, triggerWebhooks)
 
 	if err := s.eventsSvc.Notify(userID, deviceID, event); err != nil {
 		return fmt.Errorf("failed to notify device: %w", err)

--- a/internal/sms-gateway/modules/events/events.go
+++ b/internal/sms-gateway/modules/events/events.go
@@ -1,9 +1,12 @@
 package events
 
 import (
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/android-sms-gateway/client-go/smsgateway"
+	"github.com/samber/lo"
 )
 
 func NewMessageEnqueuedEvent() Event {
@@ -14,13 +17,28 @@ func NewWebhooksUpdatedEvent() Event {
 	return NewEvent(smsgateway.PushWebhooksUpdated, nil)
 }
 
-func NewMessagesExportRequestedEvent(since, until time.Time) Event {
+func NewMessagesExportRequestedEvent(
+	since, until time.Time,
+	types []smsgateway.IncomingMessageType,
+	triggerWebhooks *bool,
+) Event {
+	data := map[string]string{
+		"since": since.Format(time.RFC3339),
+		"until": until.Format(time.RFC3339),
+	}
+	if len(types) > 0 {
+		data["messageTypes"] = strings.Join(
+			lo.Map(types, func(item smsgateway.IncomingMessageType, _ int) string { return string(item) }),
+			",",
+		)
+	}
+	if triggerWebhooks != nil {
+		data["triggerWebhooks"] = strconv.FormatBool(*triggerWebhooks)
+	}
+
 	return NewEvent(
 		smsgateway.PushMessagesExportRequested,
-		map[string]string{
-			"since": since.Format(time.RFC3339),
-			"until": until.Format(time.RFC3339),
-		},
+		data,
 	)
 }
 

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -481,7 +481,7 @@ const docTemplate = `{
                         "JWTAuth": []
                     }
                 ],
-                "description": "Refreshes inbox messages. Webhooks will not be triggered.",
+                "description": "Refreshes inbox messages. Webhooks are triggered when triggerWebhooks is true.",
                 "consumes": [
                     "application/json"
                 ],
@@ -495,21 +495,18 @@ const docTemplate = `{
                 "summary": "Request inbox messages refresh",
                 "parameters": [
                     {
-                        "description": "Export inbox request",
+                        "description": "Refresh inbox request",
                         "name": "request",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/smsgateway.MessagesExportRequest"
+                            "$ref": "#/definitions/smsgateway.InboxRefreshRequest"
                         }
                     }
                 ],
                 "responses": {
                     "202": {
-                        "description": "Inbox refresh request accepted",
-                        "schema": {
-                            "type": "object"
-                        }
+                        "description": "Inbox refresh request accepted"
                     },
                     "400": {
                         "description": "Invalid request",
@@ -531,12 +528,6 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal server error",
-                        "schema": {
-                            "$ref": "#/definitions/smsgateway.ErrorResponse"
-                        }
-                    },
-                    "501": {
-                        "description": "Not implemented",
                         "schema": {
                             "$ref": "#/definitions/smsgateway.ErrorResponse"
                         }
@@ -817,73 +808,6 @@ const docTemplate = `{
                     },
                     "503": {
                         "description": "Queue limits exceeded; ensure device is online",
-                        "schema": {
-                            "$ref": "#/definitions/smsgateway.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/3rdparty/v1/messages/inbox/export": {
-            "post": {
-                "security": [
-                    {
-                        "ApiAuth": []
-                    },
-                    {
-                        "JWTAuth": []
-                    }
-                ],
-                "description": "Initiates process of inbox messages export via webhooks. For each message the ` + "`" + `sms:received` + "`" + ` webhook will be triggered. The webhooks will be triggered without specific order.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "User",
-                    "Messages"
-                ],
-                "summary": "Request inbox messages export",
-                "parameters": [
-                    {
-                        "description": "Export inbox request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/smsgateway.MessagesExportRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "202": {
-                        "description": "Inbox export request accepted",
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request",
-                        "schema": {
-                            "$ref": "#/definitions/smsgateway.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/smsgateway.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/smsgateway.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/smsgateway.ErrorResponse"
                         }
@@ -1673,6 +1597,46 @@ const docTemplate = `{
                 "HealthStatusFail"
             ]
         },
+        "smsgateway.InboxRefreshRequest": {
+            "type": "object",
+            "required": [
+                "since",
+                "until"
+            ],
+            "properties": {
+                "deviceId": {
+                    "description": "ID of the device to refresh messages for.",
+                    "type": "string",
+                    "maxLength": 21,
+                    "example": "PyDmBQZZXYmyxMwED8Fzy"
+                },
+                "messageTypes": {
+                    "description": "List of message types to refresh. By default, SMS messages are refreshed.",
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/smsgateway.IncomingMessageType"
+                    }
+                },
+                "since": {
+                    "description": "Start of the time range to refresh.",
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2024-01-01T00:00:00Z"
+                },
+                "triggerWebhooks": {
+                    "description": "Indicates whether to trigger webhooks for the refreshed messages.",
+                    "type": "boolean",
+                    "example": true
+                },
+                "until": {
+                    "description": "End of the time range to refresh.",
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2024-01-01T23:59:59Z"
+                }
+            }
+        },
         "smsgateway.IncomingMessage": {
             "type": "object",
             "required": [
@@ -1750,6 +1714,43 @@ const docTemplate = `{
                 "IncomingMessageTypeDataSMS",
                 "IncomingMessageTypeMMS",
                 "IncomingMessageTypeMmsDownloaded"
+            ]
+        },
+        "smsgateway.JWTScope": {
+            "type": "string",
+            "enum": [
+                "devices:list",
+                "devices:delete",
+                "inbox:list",
+                "inbox:refresh",
+                "logs:read",
+                "messages:send",
+                "messages:read",
+                "messages:list",
+                "messages:export",
+                "settings:read",
+                "settings:write",
+                "tokens:manage",
+                "webhooks:list",
+                "webhooks:write",
+                "webhooks:delete"
+            ],
+            "x-enum-varnames": [
+                "ScopeDevicesList",
+                "ScopeDevicesDelete",
+                "ScopeInboxList",
+                "ScopeInboxRefresh",
+                "ScopeLogsRead",
+                "ScopeMessagesSend",
+                "ScopeMessagesRead",
+                "ScopeMessagesList",
+                "ScopeMessagesExport",
+                "ScopeSettingsRead",
+                "ScopeSettingsWrite",
+                "ScopeTokensManage",
+                "ScopeWebhooksList",
+                "ScopeWebhooksWrite",
+                "ScopeWebhooksDelete"
             ]
         },
         "smsgateway.LimitPeriod": {
@@ -2024,32 +2025,6 @@ const docTemplate = `{
                 }
             }
         },
-        "smsgateway.MessagesExportRequest": {
-            "type": "object",
-            "required": [
-                "deviceId",
-                "since",
-                "until"
-            ],
-            "properties": {
-                "deviceId": {
-                    "description": "DeviceID is the ID of the device to export messages for.",
-                    "type": "string",
-                    "maxLength": 21,
-                    "example": "PyDmBQZZXYmyxMwED8Fzy"
-                },
-                "since": {
-                    "description": "Since is the start of the time range to export.",
-                    "type": "string",
-                    "example": "2024-01-01T00:00:00Z"
-                },
-                "until": {
-                    "description": "Until is the end of the time range to export.",
-                    "type": "string",
-                    "example": "2024-01-01T23:59:59Z"
-                }
-            }
-        },
         "smsgateway.MessagesProcessingOrder": {
             "type": "string",
             "enum": [
@@ -2293,7 +2268,7 @@ const docTemplate = `{
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/smsgateway.JWTScope"
                     }
                 },
                 "ttl": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented inbox refresh endpoint: accepts deviceId, since/until, optional message-type filtering, and explicit webhook-trigger control; validates input and returns 202 Accepted on success.
  * Added API workflow examples to capture deviceId and exercise inbox refresh.

* **Deprecations**
  * Legacy inbox export endpoint marked deprecated and now returns a Deprecation response header.

* **Documentation**
  * OpenAPI updated: new request schema, removed legacy export operation, and webhook-trigger behavior documented.

* **Chores**
  * Updated a client dependency version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/android-sms-gateway/server/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->