### PR TITLE
feat: get password from existing secret

### DIFF
--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -51,6 +51,9 @@ The following table lists the configurable parameters of the SMSGate chart and t
 | `database.port`                                 | Database port                         | `3306`                                                                              |
 | `database.user`                                 | Database user                         | `sms`                                                                               |
 | `database.password`                             | Database password                     | `""`                                                                                |
+| `database.existingSecret`                             | Existing secret for database                     | `{}`                                                                                |
+| `database.existingSecret.secretName`                             | Existing secret name                     | `""`                                                                                |
+| `database.existingSecret.passwordKey`                             | Existing secret password key                     | `""`                                                                                |
 | `database.name`                                 | Database name                         | `sms`                                                                               |
 | `database.deployInternal`                       | Deploy internal MariaDB               | `true`                                                                              |
 | `gateway.privateToken`                          | Private token for device registration | `""`                                                                                |

--- a/deployments/helm-chart/templates/database.yaml
+++ b/deployments/helm-chart/templates/database.yaml
@@ -35,8 +35,8 @@ spec:
             - name: MARIADB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "sms-gateway.fullname" . }}-db-secrets
-                  key: database-password
+                  name: {{ .Values.database.existingSecret.secretName | default (printf "%s-db-secrets" (include "sms-gateway.fullname" .)) }}
+                  key: {{ .Values.database.existingSecret.passwordKey | default ("database-password") }}
           ports:
             - name: mysql
               containerPort: 3306
@@ -92,7 +92,9 @@ metadata:
 type: Opaque
 data:
   root-password: {{ .Values.database.mariadb.rootPassword | b64enc | quote }}
+{{- if not .Values.database.existingSecret }}
   database-password: {{ .Values.database.password | b64enc | quote }}
+{{- end }}
 
 ---
 # Database Persistent Volume Claim

--- a/deployments/helm-chart/templates/deployment.yaml
+++ b/deployments/helm-chart/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: DATABASE__HOST
               value: {{ .Values.database.host }}
             {{- end }}
-            - name: DATABASE__NAME
+            - name: DATABASE__DATABASE
               value: {{ .Values.database.name }}
             - name: DATABASE__USER
               value: {{ .Values.database.user }}
@@ -197,15 +197,15 @@ spec:
             - name: DATABASE__HOST
               value: {{ .Values.database.host }}
             {{- end }}
-            - name: DATABASE__NAME
+            - name: DATABASE__DATABASE
               value: {{ .Values.database.name }}
             - name: DATABASE__USER
               value: {{ .Values.database.user }}
             - name: DATABASE__PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "sms-gateway.fullname" . }}-secrets
-                  key: database-password
+                  name: {{ .Values.database.existingSecret.secretName | default (printf "%s-secret" (include "sms-gateway.fullname" .)) }}
+                  key: {{ .Values.database.existingSecret.passwordKey | default ("database-password") }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/deployments/helm-chart/templates/deployment.yaml
+++ b/deployments/helm-chart/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
             - name: DATABASE__PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "sms-gateway.fullname" . }}-secrets
-                  key: database-password
+                  name: {{ .Values.database.existingSecret.secretName | default (printf "%s-secret" (include "sms-gateway.fullname" .)) }}
+                  key: {{ .Values.database.existingSecret.passwordKey | default ("database-password") }}
             {{- if .Values.gateway.privateToken }}
             - name: GATEWAY__MODE
               value: "private"

--- a/deployments/helm-chart/templates/secrets.yaml
+++ b/deployments/helm-chart/templates/secrets.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "sms-gateway.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if not .Values.database.existingSecret }}
   database-password: {{ .Values.database.password | b64enc | quote }}
+  {{- end }}
   {{- if .Values.gateway.privateToken }}
   private-token: {{ .Values.gateway.privateToken | b64enc | quote }}
   {{- end }}

--- a/deployments/helm-chart/values.yaml
+++ b/deployments/helm-chart/values.yaml
@@ -81,6 +81,9 @@ database:
   user: sms
   password: "" # REQUIRED: Set a strong password for the database user
   name: sms
+  existingSecret: {}
+  #   secretName: existing-secret-name
+  #   passwordKey: password
   # Set to true to deploy a MariaDB instance with the chart
   deployInternal: true
   mariadb:


### PR DESCRIPTION
fallback to default values
update README.md

Context: We use [mariadb-operator](https://mariadb-operator.github.io/mariadb-operator) to create new MariaDB instance in our cluster, which expects an already deployed secret. In order to stick to our naming conventions we would like to override the name of the secret which is used by the sms-gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support in the Helm chart for using an externally managed Kubernetes Secret for the MariaDB password via `database.existingSecret.secretName` and `database.existingSecret.passwordKey`.
* **Documentation**
  * Updated the Helm chart README/values to describe the new `database.existingSecret` configuration.
* **Bug Fixes**
  * Updated the main and worker Deployments to use the correct database environment variable name and to source the password from the configured existing Secret.
* **Chores**
  * Improved conditional rendering so the chart-created database password is only generated when an existing Secret is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->