### PR TITLE
[webhooks] add `app:started` webhook support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.20.0
-	github.com/android-sms-gateway/client-go v1.13.0
+	github.com/android-sms-gateway/client-go v1.13.1
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,10 @@ github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
 github.com/android-sms-gateway/client-go v1.13.0 h1:EvKDi796R2ScCAiaekWYRekVjkjiJGK3d/LZcPKpfQQ=
 github.com/android-sms-gateway/client-go v1.13.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.13.1-0.20260615045907-7da52ca08232 h1:5oXhQOh+utEQmODk6v5VEa1f8y2BqOPZrDKpL9rNNHw=
+github.com/android-sms-gateway/client-go v1.13.1-0.20260615045907-7da52ca08232/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.13.1 h1:532Pq7rlCtkXB4In5R8X8GPWUhkiIZlrKlhzSDoxUPU=
+github.com/android-sms-gateway/client-go v1.13.1/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -2380,9 +2380,11 @@ const docTemplate = `{
                 "sms:failed",
                 "system:ping",
                 "mms:received",
-                "mms:downloaded"
+                "mms:downloaded",
+                "app:started"
             ],
             "x-enum-comments": {
+                "WebhookEventAppStarted": "Triggered when the application is started.",
                 "WebhookEventMmsDownloaded": "Triggered when an MMS is downloaded.",
                 "WebhookEventMmsReceived": "Triggered when an MMS is received.",
                 "WebhookEventSmsDataReceived": "Triggered when a data SMS is received.",
@@ -2400,7 +2402,8 @@ const docTemplate = `{
                 "Triggered when an SMS processing fails.",
                 "Triggered when the device pings the server.",
                 "Triggered when an MMS is received.",
-                "Triggered when an MMS is downloaded."
+                "Triggered when an MMS is downloaded.",
+                "Triggered when the application is started."
             ],
             "x-enum-varnames": [
                 "WebhookEventSmsReceived",
@@ -2410,7 +2413,8 @@ const docTemplate = `{
                 "WebhookEventSmsFailed",
                 "WebhookEventSystemPing",
                 "WebhookEventMmsReceived",
-                "WebhookEventMmsDownloaded"
+                "WebhookEventMmsDownloaded",
+                "WebhookEventAppStarted"
             ]
         }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `app:started` webhook event so applications can receive startup notifications.
  * Updated API documentation to include the new `app:started` event.
* **Chores**
  * Updated the SMS Gateway client dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->