### PR TITLE
[handlers] add link response headers

### DIFF
--- a/api/requests.http
+++ b/api/requests.http
@@ -278,6 +278,9 @@ Content-Type: application/json
 }
 
 ###
+GET http://localhost:3000/ HTTP/1.1
+
+###
 GET http://localhost:3000/metrics HTTP/1.1
 
 ###

--- a/internal/sms-gateway/handlers/root.go
+++ b/internal/sms-gateway/handlers/root.go
@@ -16,6 +16,8 @@ type rootHandler struct {
 }
 
 func (h *rootHandler) Register(app *fiber.App) {
+	app.Use(h.setLinkHeaders)
+
 	if h.config.PublicPath != "/api" {
 		app.Use(func(c *fiber.Ctx) error {
 			err := c.Next()
@@ -32,6 +34,17 @@ func (h *rootHandler) Register(app *fiber.App) {
 	h.healthHandler.Register(app)
 
 	h.registerOpenAPI(app)
+}
+
+func (h *rootHandler) setLinkHeaders(c *fiber.Ctx) error {
+	publicPath := strings.TrimRight(h.config.PublicPath, "/")
+	c.Set(fiber.HeaderLink,
+		`</.well-known/api-catalog>; rel="api-catalog", `+
+			`<`+publicPath+`/docs/doc.json>; rel="service-desc", `+
+			`<https://docs.sms-gate.app/>; rel="service-doc", `+
+			`</.well-known/api-catalog>; rel="describedby"`,
+	)
+	return c.Next() //nolint:wrapcheck // passed through to fiber's error handler
 }
 
 func (h *rootHandler) registerOpenAPI(router fiber.Router) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Root responses now include `Link` headers that point to the API catalog and service documentation.
* **Chores**
  * Updated local request examples to include a call to the root endpoint (`GET /`), placed before the metrics request example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->