### PR TITLE
[messages] cancellation support

### DIFF
--- a/api/local.http
+++ b/api/local.http
@@ -23,7 +23,7 @@ Authorization: Basic {{localCredentials}}
     "phoneNumbers": [
         "{{phone}}"
     ],
-    "simNumber": {{$randomInt 0 3}},
+    "simNumber": {{$randomInt 1 3}},
     "withDeliveryReport": true
 }
 
@@ -111,6 +111,10 @@ Authorization: Basic {{localCredentials}}
 
 ###
 GET {{localUrl}}/messages/{{messageId}} HTTP/1.1
+Authorization: Basic {{localCredentials}}
+
+###
+DELETE {{localUrl}}/messages/{{messageId}} HTTP/1.1
 Authorization: Basic {{localCredentials}}
 
 ###

--- a/api/requests.http
+++ b/api/requests.http
@@ -103,6 +103,11 @@ Authorization: Basic {{credentials}}
 # Authorization: Bearer {{jwtToken}}
 
 ###
+DELETE {{baseUrl}}/3rdparty/v1/messages/{{messageId}} HTTP/1.1
+Authorization: Basic {{credentials}}
+# Authorization: Bearer {{jwtToken}}
+
+###
 GET {{baseUrl}}/3rdparty/v1/messages HTTP/1.1
 Authorization: Basic {{credentials}}
 # Authorization: Bearer {{jwtToken}}
@@ -234,6 +239,7 @@ Content-Type: application/json
     "scopes": [
         "messages:send",
         "messages:read",
+        "messages:cancel",
         "devices:list",
         "devices:write",
         "webhooks:list",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.20.0
-	github.com/android-sms-gateway/client-go v1.13.2
+	github.com/android-sms-gateway/client-go v1.14.0
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -38,10 +38,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/android-sms-gateway/client-go v1.13.2-0.20260626014509-89d2208e1948 h1:q/x54LvDLVMMfsypcc0DZEIdxVLgdvO84t754Q0RlUI=
-github.com/android-sms-gateway/client-go v1.13.2-0.20260626014509-89d2208e1948/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
-github.com/android-sms-gateway/client-go v1.13.2 h1:GQUlN4O9d/UEd50AJ01p2ssC4t8qUv3yALR5+tNtzEI=
-github.com/android-sms-gateway/client-go v1.13.2/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.14.0 h1:CyKb8NgmOJZ+xOpBjY+Qv5Cj3vSSy6MoaDuI6G5oRLY=
+github.com/android-sms-gateway/client-go v1.14.0/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/handlers/converters/messages.go
+++ b/internal/sms-gateway/handlers/converters/messages.go
@@ -40,6 +40,7 @@ func MessageToMobileDTO(m messages.Message) smsgateway.MobileMessage {
 			ScheduleAt:         m.ScheduleAt,
 			Priority:           m.Priority,
 		},
+		State:     smsgateway.ProcessingState(m.State),
 		CreatedAt: m.CreatedAt,
 	}
 }

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -246,6 +246,32 @@ func (h *ThirdPartyController) get(userID string, c *fiber.Ctx) error {
 	return c.JSON(converters.MessageStateToDTO(*state))
 }
 
+//	@Summary		Cancel message
+//	@Description	Cancels a pending message by ID. The message must be in Pending state.
+//	@Security		ApiAuth
+//	@Security		JWTAuth
+//	@Tags			User, Messages
+//	@Param			id	path		string							true	"Message ID"
+//	@Success		200	{object}	smsgateway.GetMessageResponse	"Message state after cancellation"
+//	@Failure		400	{object}	smsgateway.ErrorResponse		"Invalid request"
+//	@Failure		401	{object}	smsgateway.ErrorResponse		"Unauthorized"
+//	@Failure		403	{object}	smsgateway.ErrorResponse		"Forbidden"
+//	@Failure		404	{object}	smsgateway.ErrorResponse		"Message not found"
+//	@Failure		500	{object}	smsgateway.ErrorResponse		"Internal server error"
+//	@Router			/3rdparty/v1/messages/{id} [delete]
+//
+// Cancel message.
+func (h *ThirdPartyController) delete(userID string, c *fiber.Ctx) error {
+	id := c.Params("id")
+
+	state, err := h.messagesSvc.CancelMessage(userID, id)
+	if err != nil {
+		return fmt.Errorf("failed to cancel message: %w", err)
+	}
+
+	return c.JSON(converters.MessageStateToDTO(*state))
+}
+
 // Export inbox.
 //
 // Deprecated: use /3rdparty/v1/inbox/refresh instead.
@@ -283,11 +309,9 @@ func (h *ThirdPartyController) errorHandler(c *fiber.Ctx) error {
 
 	var msgValidationError messages.ValidationError
 	switch {
-	case errors.As(err, &msgValidationError):
-		fallthrough
-	case errors.Is(err, messages.ErrMultipleMessagesFound):
-		fallthrough
-	case errors.Is(err, messages.ErrNoContent):
+	case errors.As(err, &msgValidationError),
+		errors.Is(err, messages.ErrMultipleMessagesFound),
+		errors.Is(err, messages.ErrNoContent):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 
 	case errors.Is(err, messages.ErrMessageNotFound):
@@ -319,6 +343,7 @@ func (h *ThirdPartyController) Register(router fiber.Router) {
 	router.Get("", permissions.RequireScope(ScopeList), userauth.WithUserID(h.list))
 	router.Post("", permissions.RequireScope(ScopeSend), userauth.WithUserID(h.post))
 	router.Get(":id", permissions.RequireScope(ScopeRead), userauth.WithUserID(h.get)).Name(route3rdPartyGetMessage)
+	router.Delete(":id", permissions.RequireScope(ScopeCancel), userauth.WithUserID(h.delete))
 
 	router.Post("inbox/export", permissions.RequireScope(ScopeExport), userauth.WithUserID(h.postInboxExport))
 }

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -15,7 +15,7 @@ type thirdPartyPostQueryParams struct {
 type thirdPartyGetQueryParams struct {
 	StartDate      string `query:"from"           validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
 	EndDate        string `query:"to"             validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
-	State          string `query:"state"          validate:"omitempty,oneof=Pending Processed Sent Delivered Failed"`
+	State          string `query:"state"          validate:"omitempty,oneof=Pending Cancelling Cancelled Processed Sent Delivered Failed"`
 	DeviceID       string `query:"deviceId"       validate:"omitempty,len=21"`
 	Limit          int    `query:"limit"          validate:"omitempty,min=1,max=100"`
 	Offset         int    `query:"offset"         validate:"omitempty,min=0"`
@@ -46,7 +46,7 @@ func (p *thirdPartyGetQueryParams) ToFilter() messages.SelectFilter {
 	}
 
 	if p.State != "" {
-		filter.State = messages.ProcessingState(p.State)
+		filter.State = append(filter.State, messages.ProcessingState(p.State))
 	}
 
 	if p.DeviceID != "" {

--- a/internal/sms-gateway/handlers/messages/permissions.go
+++ b/internal/sms-gateway/handlers/messages/permissions.go
@@ -10,6 +10,8 @@ const (
 	ScopeRead = smsgateway.ScopeMessagesRead
 	// ScopeList is the permission scope required for listing messages.
 	ScopeList = smsgateway.ScopeMessagesList
+	// ScopeCancel is the permission scope required for cancelling messages.
+	ScopeCancel = smsgateway.ScopeMessagesCancel
 	// ScopeExport is the permission scope required for exporting messages.
 	ScopeExport = smsgateway.ScopeMessagesExport
 )

--- a/internal/sms-gateway/models/migrations/mysql/20260617000000_add_cancelled_message_state.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260617000000_add_cancelled_message_state.sql
@@ -1,0 +1,96 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `messages`
+MODIFY COLUMN `state` enum(
+        'Pending',
+        'Cancelling',
+        'Cancelled',
+        'Processed',
+        'Sent',
+        'Delivered',
+        'Failed'
+    ) NOT NULL DEFAULT 'Pending';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `message_recipients`
+MODIFY COLUMN `state` enum(
+        'Pending',
+        'Cancelling',
+        'Cancelled',
+        'Processed',
+        'Sent',
+        'Delivered',
+        'Failed'
+    ) NOT NULL DEFAULT 'Pending';
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `message_states`
+MODIFY COLUMN `state` enum(
+        'Pending',
+        'Cancelling',
+        'Cancelled',
+        'Processed',
+        'Sent',
+        'Delivered',
+        'Failed'
+    ) NOT NULL;
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+UPDATE `messages`
+SET `state` = CASE
+        WHEN `state` = 'Cancelling' THEN 'Pending'
+        WHEN `state` = 'Cancelled' THEN 'Failed'
+        ELSE `state`
+    END
+WHERE `state` IN ('Cancelling', 'Cancelled');
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `messages`
+MODIFY COLUMN `state` enum(
+        'Pending',
+        'Processed',
+        'Sent',
+        'Delivered',
+        'Failed'
+    ) NOT NULL DEFAULT 'Pending';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE `message_recipients`
+SET `state` = CASE
+        WHEN `state` = 'Cancelling' THEN 'Pending'
+        WHEN `state` = 'Cancelled' THEN 'Failed'
+        ELSE `state`
+    END
+WHERE `state` IN ('Cancelling', 'Cancelled');
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `message_recipients`
+MODIFY COLUMN `state` enum(
+        'Pending',
+        'Processed',
+        'Sent',
+        'Delivered',
+        'Failed'
+    ) NOT NULL DEFAULT 'Pending';
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE `message_states`
+SET `state` = CASE
+        WHEN `state` = 'Cancelling' THEN 'Pending'
+        WHEN `state` = 'Cancelled' THEN 'Failed'
+        ELSE `state`
+    END
+WHERE `state` IN ('Cancelling', 'Cancelled');
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `message_states`
+MODIFY COLUMN `state` enum(
+        'Pending',
+        'Processed',
+        'Sent',
+        'Delivered',
+        'Failed'
+    ) NOT NULL;
+-- +goose StatementEnd

--- a/internal/sms-gateway/modules/events/events.go
+++ b/internal/sms-gateway/modules/events/events.go
@@ -42,6 +42,12 @@ func NewMessagesExportRequestedEvent(
 	)
 }
 
+func NewMessageCancelledEvent(messageID string) Event {
+	return NewEvent(smsgateway.PushMessageCancelled, map[string]string{
+		"messageId": messageID,
+	})
+}
+
 func NewSettingsUpdatedEvent() Event {
 	return NewEvent(smsgateway.PushSettingsUpdated, nil)
 }

--- a/internal/sms-gateway/modules/messages/cache.go
+++ b/internal/sms-gateway/modules/messages/cache.go
@@ -3,6 +3,7 @@ package messages
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -69,4 +70,13 @@ func (c *stateCache) Get(ctx context.Context, userID, id string) (*MessageState,
 	}
 
 	return message, nil
+}
+
+func (c *stateCache) Delete(ctx context.Context, userID, id string) error {
+	err := c.storage.Delete(ctx, userID+":"+id)
+	if err == nil || errors.Is(err, cacheImpl.ErrKeyNotFound) {
+		return nil
+	}
+
+	return fmt.Errorf("failed to delete message from cache: %w", err)
 }

--- a/internal/sms-gateway/modules/messages/converters.go
+++ b/internal/sms-gateway/modules/messages/converters.go
@@ -43,6 +43,7 @@ func messageToDomain(input messageModel) (Message, error) {
 			ScheduleAt:         input.ScheduleAt,
 			Priority:           smsgateway.MessagePriority(input.Priority),
 		},
+		State:     input.State,
 		CreatedAt: input.CreatedAt,
 	}, nil
 }

--- a/internal/sms-gateway/modules/messages/domain.go
+++ b/internal/sms-gateway/modules/messages/domain.go
@@ -40,6 +40,7 @@ type MessageInput struct {
 type Message struct {
 	MessageInput
 
+	State     ProcessingState
 	CreatedAt time.Time
 }
 

--- a/internal/sms-gateway/modules/messages/errors.go
+++ b/internal/sms-gateway/modules/messages/errors.go
@@ -7,6 +7,7 @@ var (
 	ErrMessageNotFound       = errors.New("message not found")
 	ErrMultipleMessagesFound = errors.New("multiple messages found")
 	ErrNoContent             = errors.New("no text or data content")
+	ErrMessageNotPending     = errors.New("message is not pending")
 
 	ErrQueueLimitExceeded = errors.New("queue limits exceeded")
 )

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -16,11 +16,13 @@ type ProcessingState string
 type MessageType string
 
 const (
-	ProcessingStatePending   ProcessingState = "Pending"
-	ProcessingStateProcessed ProcessingState = "Processed"
-	ProcessingStateSent      ProcessingState = "Sent"
-	ProcessingStateDelivered ProcessingState = "Delivered"
-	ProcessingStateFailed    ProcessingState = "Failed"
+	ProcessingStatePending    ProcessingState = "Pending"
+	ProcessingStateCancelling ProcessingState = "Cancelling"
+	ProcessingStateCancelled  ProcessingState = "Cancelled"
+	ProcessingStateProcessed  ProcessingState = "Processed"
+	ProcessingStateSent       ProcessingState = "Sent"
+	ProcessingStateDelivered  ProcessingState = "Delivered"
+	ProcessingStateFailed     ProcessingState = "Failed"
 
 	MessageTypeText MessageType = "Text"
 	MessageTypeData MessageType = "Data"
@@ -34,7 +36,7 @@ type messageModel struct {
 	ExtID              string          `gorm:"not null;type:varchar(36);uniqueIndex:unq_messages_id_device,priority:1"`
 	Type               MessageType     `gorm:"not null;type:enum('Text','Data');default:Text"`
 	Content            string          `gorm:"not null;type:text"`
-	State              ProcessingState `gorm:"not null;type:enum('Pending','Sent','Processed','Delivered','Failed');default:Pending;index:idx_messages_device_state"`
+	State              ProcessingState `gorm:"not null;type:enum('Pending','Cancelling','Cancelled','Processed','Sent','Delivered','Failed');default:Pending;index:idx_messages_device_state"`
 	ValidUntil         *time.Time      `gorm:"type:datetime"`
 	ScheduleAt         *time.Time      `gorm:"type:datetime"`
 	SimNumber          *uint8          `gorm:"type:tinyint(1) unsigned"`
@@ -197,7 +199,7 @@ type messageRecipientModel struct {
 	ID          uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
 	MessageID   uint64          `gorm:"uniqueIndex:unq_message_recipients_message_id_phone_number,priority:1;type:BIGINT UNSIGNED"`
 	PhoneNumber string          `gorm:"uniqueIndex:unq_message_recipients_message_id_phone_number,priority:2;type:varchar(128)"`
-	State       ProcessingState `gorm:"not null;type:enum('Pending','Sent','Processed','Delivered','Failed');default:Pending"`
+	State       ProcessingState `gorm:"not null;type:enum('Pending','Cancelling','Cancelled','Processed','Sent','Delivered','Failed');default:Pending"`
 	Error       *string         `gorm:"type:varchar(256)"`
 }
 
@@ -226,7 +228,7 @@ func (m *messageRecipientModel) toDomain() smsgateway.RecipientState {
 type messageStateModel struct {
 	ID        uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
 	MessageID uint64          `gorm:"not null;type:BIGINT UNSIGNED;uniqueIndex:unq_message_states_message_id_state,priority:1"`
-	State     ProcessingState `gorm:"not null;type:enum('Pending','Sent','Processed','Delivered','Failed');uniqueIndex:unq_message_states_message_id_state,priority:2"`
+	State     ProcessingState `gorm:"not null;type:enum('Pending','Cancelling','Cancelled','Processed','Sent','Delivered','Failed');uniqueIndex:unq_message_states_message_id_state,priority:2"`
 	UpdatedAt time.Time       `gorm:"<-:create;not null;autoupdatetime:false"`
 }
 

--- a/internal/sms-gateway/modules/messages/repository.go
+++ b/internal/sms-gateway/modules/messages/repository.go
@@ -47,8 +47,8 @@ func (r *Repository) list(filter SelectFilter, options SelectOptions) ([]message
 	}
 
 	// Apply state filter
-	if filter.State != "" {
-		query = query.Where("messages.state = ?", filter.State)
+	if len(filter.State) > 0 {
+		query = query.Where("messages.state IN ?", filter.State)
 	}
 
 	// Apply device filter
@@ -103,7 +103,7 @@ func (r *Repository) list(filter SelectFilter, options SelectOptions) ([]message
 
 func (r *Repository) listPending(deviceID string, order Order) ([]messageModel, error) {
 	messages, _, err := r.list(
-		*new(SelectFilter).WithDeviceID(deviceID).WithState(ProcessingStatePending),
+		*new(SelectFilter).WithDeviceID(deviceID).WithState(ProcessingStatePending).WithState(ProcessingStateCancelling),
 		*new(SelectOptions).IncludeContent().IncludeRecipients().WithLimit(maxPendingBatch).WithOrderBy(order),
 	)
 
@@ -177,7 +177,7 @@ func (r *Repository) UpdateState(message *messageModel) error {
 func (r *Repository) HashProcessed(ctx context.Context, ids []uint64) (int64, error) {
 	rawSQL := "UPDATE `messages` `m`, `message_recipients` `r`\n" +
 		"SET `m`.`is_hashed` = true, `m`.`content` = SHA2(COALESCE(JSON_VALUE(`content`, '$.text'), JSON_VALUE(`content`, '$.data')), 256), `r`.`phone_number` = LEFT(SHA2(phone_number, 256), 16)\n" +
-		"WHERE `m`.`id` = `r`.`message_id` AND `m`.`is_hashed` = false AND `m`.`is_encrypted` = false AND `m`.`state` <> 'Pending'"
+		"WHERE `m`.`id` = `r`.`message_id` AND `m`.`is_hashed` = false AND `m`.`is_encrypted` = false AND `m`.`state` NOT IN ('Pending', 'Cancelling')"
 	params := []any{}
 	if len(ids) > 0 {
 		rawSQL += " AND `m`.`id` IN (?)"
@@ -193,10 +193,24 @@ func (r *Repository) HashProcessed(ctx context.Context, ids []uint64) (int64, er
 	return res.RowsAffected, nil
 }
 
+func (r *Repository) CancelMessage(userID string, id string) error {
+	res := r.db.Model((*messageModel)(nil)).
+		Where("ext_id = ? AND state = ?", id, ProcessingStatePending).
+		Where("device_id IN (?)", r.db.Table("devices").Select("id").Where("user_id = ?", userID)).
+		Update("state", ProcessingStateCancelling)
+	if res.Error != nil {
+		return fmt.Errorf("failed to cancel message: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrMessageNotPending
+	}
+	return nil
+}
+
 func (r *Repository) Cleanup(ctx context.Context, until time.Time) (int64, error) {
 	res := r.db.
 		WithContext(ctx).
-		Where("state <> ?", ProcessingStatePending).
+		Where("state NOT IN ?", []ProcessingState{ProcessingStatePending, ProcessingStateCancelling}).
 		Where("created_at < ?", until).
 		Delete(new(messageModel))
 	return res.RowsAffected, res.Error

--- a/internal/sms-gateway/modules/messages/repository_filter.go
+++ b/internal/sms-gateway/modules/messages/repository_filter.go
@@ -19,7 +19,7 @@ type SelectFilter struct {
 	DeviceID  string
 	StartDate time.Time
 	EndDate   time.Time
-	State     ProcessingState
+	State     []ProcessingState
 }
 
 func (f *SelectFilter) WithExtID(extID string) *SelectFilter {
@@ -44,7 +44,7 @@ func (f *SelectFilter) WithDateRange(start, end time.Time) *SelectFilter {
 }
 
 func (f *SelectFilter) WithState(state ProcessingState) *SelectFilter {
-	f.State = state
+	f.State = append(f.State, state)
 	return f
 }
 

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -204,6 +204,40 @@ func (s *Service) GetState(userID string, id string) (*MessageState, error) {
 	return state, nil
 }
 
+// CancelMessage transitions a pending message to Cancelling state.
+// Returns an error if the message is not in Pending state.
+func (s *Service) CancelMessage(userID string, id string) (*MessageState, error) {
+	message, err := s.messages.get(
+		*new(SelectFilter).WithExtID(id).WithUserID(userID),
+		*new(SelectOptions).IncludeDevice().IncludeStates(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if cancelErr := s.messages.CancelMessage(userID, id); cancelErr != nil {
+		return nil, cancelErr
+	}
+
+	if cacheErr := s.cache.Delete(context.Background(), userID, id); cacheErr != nil {
+		s.logger.Warn("failed to invalidate message cache", zap.String("id", id), zap.Error(cacheErr))
+	}
+
+	// Notify device about cancellation
+	go func(userID, deviceID, messageID string) {
+		if ntfErr := s.eventsSvc.Notify(userID, &deviceID, events.NewMessageCancelledEvent(messageID)); ntfErr != nil {
+			s.logger.Error(
+				"failed to notify device about cancellation",
+				zap.Error(ntfErr),
+				zap.String("user_id", userID),
+				zap.String("device_id", deviceID),
+			)
+		}
+	}(userID, message.DeviceID, id)
+
+	return s.GetState(userID, id)
+}
+
 func (s *Service) Enqueue(
 	ctx context.Context,
 	device devices.Device,

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -875,6 +875,69 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiAuth": []
+                    },
+                    {
+                        "JWTAuth": []
+                    }
+                ],
+                "description": "Cancels a pending message by ID. The message must be in Pending state.",
+                "tags": [
+                    "User",
+                    "Messages"
+                ],
+                "summary": "Cancel message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Message ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Message state after cancellation",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.GetMessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Message not found",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/smsgateway.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/3rdparty/v1/settings": {
@@ -1739,6 +1802,7 @@ const docTemplate = `{
                 "inbox:list",
                 "inbox:refresh",
                 "logs:read",
+                "messages:cancel",
                 "messages:send",
                 "messages:read",
                 "messages:list",
@@ -1756,6 +1820,7 @@ const docTemplate = `{
                 "ScopeInboxList",
                 "ScopeInboxRefresh",
                 "ScopeLogsRead",
+                "ScopeMessagesCancel",
                 "ScopeMessagesSend",
                 "ScopeMessagesRead",
                 "ScopeMessagesList",
@@ -1773,12 +1838,14 @@ const docTemplate = `{
             "enum": [
                 "Disabled",
                 "PerMinute",
+                "Per30Minutes",
                 "PerHour",
                 "PerDay"
             ],
             "x-enum-varnames": [
                 "Disabled",
                 "PerMinute",
+                "Per30Minutes",
                 "PerHour",
                 "PerDay"
             ]
@@ -2055,12 +2122,16 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "Pending",
+                "Cancelling",
+                "Cancelled",
                 "Processed",
                 "Sent",
                 "Delivered",
                 "Failed"
             ],
             "x-enum-comments": {
+                "ProcessingStateCancelled": "Cancelled",
+                "ProcessingStateCancelling": "Cancelling (cancellation requested)",
                 "ProcessingStateDelivered": "Delivered",
                 "ProcessingStateFailed": "Failed",
                 "ProcessingStatePending": "Pending",
@@ -2069,6 +2140,8 @@ const docTemplate = `{
             },
             "x-enum-descriptions": [
                 "Pending",
+                "Cancelling (cancellation requested)",
+                "Cancelled",
                 "Processed (received by device)",
                 "Sent",
                 "Delivered",
@@ -2076,6 +2149,8 @@ const docTemplate = `{
             ],
             "x-enum-varnames": [
                 "ProcessingStatePending",
+                "ProcessingStateCancelling",
+                "ProcessingStateCancelled",
                 "ProcessingStateProcessed",
                 "ProcessingStateSent",
                 "ProcessingStateDelivered",
@@ -2156,10 +2231,11 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "limit_period": {
-                    "description": "LimitPeriod defines the period for message sending limits.\nValid values are \"Disabled\", \"PerMinute\", \"PerHour\", or \"PerDay\".",
+                    "description": "LimitPeriod defines the period for message sending limits.\nValid values are \"Disabled\", \"PerMinute\", \"Per30Minutes\", \"PerHour\", or \"PerDay\".",
                     "enum": [
                         "Disabled",
                         "PerMinute",
+                        "Per30Minutes",
                         "PerHour",
                         "PerDay"
                     ],
@@ -2395,6 +2471,7 @@ const docTemplate = `{
                 "sms:sent",
                 "sms:delivered",
                 "sms:failed",
+                "sms:cancelled",
                 "system:ping",
                 "mms:received",
                 "mms:downloaded",
@@ -2404,6 +2481,7 @@ const docTemplate = `{
                 "WebhookEventAppStarted": "Triggered when the application is started.",
                 "WebhookEventMmsDownloaded": "Triggered when an MMS is downloaded.",
                 "WebhookEventMmsReceived": "Triggered when an MMS is received.",
+                "WebhookEventSmsCancelled": "Triggered when an SMS is cancelled.",
                 "WebhookEventSmsDataReceived": "Triggered when a data SMS is received.",
                 "WebhookEventSmsDelivered": "Triggered when an SMS is delivered.",
                 "WebhookEventSmsFailed": "Triggered when an SMS processing fails.",
@@ -2417,6 +2495,7 @@ const docTemplate = `{
                 "Triggered when an SMS is sent.",
                 "Triggered when an SMS is delivered.",
                 "Triggered when an SMS processing fails.",
+                "Triggered when an SMS is cancelled.",
                 "Triggered when the device pings the server.",
                 "Triggered when an MMS is received.",
                 "Triggered when an MMS is downloaded.",
@@ -2428,6 +2507,7 @@ const docTemplate = `{
                 "WebhookEventSmsSent",
                 "WebhookEventSmsDelivered",
                 "WebhookEventSmsFailed",
+                "WebhookEventSmsCancelled",
                 "WebhookEventSystemPing",
                 "WebhookEventMmsReceived",
                 "WebhookEventMmsDownloaded",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added third-party message cancellation via `DELETE /3rdparty/v1/messages/{id}` (requires `messages:cancel`), returning the updated message state.
  * Introduced `Cancelling` and `Cancelled` processing states.
  * Added `sms:cancelled` webhook/event for cancelled messages.
* **Improvements**
  * Extended state validation, filtering, and repository/service logic to support cancellation.
  * Updated Swagger/OpenAPI documentation and local/request HTTP examples.
* **Chores**
  * Added the database migration for the new message states and updated a Go dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->