### PR TITLE
[migrations] use expression syntax for JSON default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,16 +79,19 @@ HTTP__OPENAPI__ENABLED=false
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================
+# Database Compatibility:
+#   MySQL 8.0.13+ or MariaDB 10.2.7+
+#   MariaDB LTS is the recommended deployment target
 
 # Database host
-# Purpose: Hostname of the MySQL database server
+# Purpose: Hostname of the MySQL/MariaDB database server
 # Format: String (hostname or IP)
 # Default: localhost
 # Example: localhost
 DATABASE__HOST=localhost
 
 # Database port
-# Purpose: Port number of the MySQL database server
+# Purpose: Port number of the MySQL/MariaDB database server
 # Format: Integer
 # Default: 3306
 # Example: 3306
@@ -107,7 +110,7 @@ DATABASE__USER=smsgateway
 DATABASE__PASSWORD=smsgateway
 
 # Database name
-# Purpose: Name of the MySQL database
+# Purpose: Name of the MySQL/MariaDB database
 # Format: String
 # Example: smsgateway
 DATABASE__DATABASE=smsgateway

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This server acts as the backend component of the [SMSGate](https://github.com/ca
 
 - Go (for development and testing purposes)
 - Docker and Docker Compose (for Docker-based setup)
-- A configured MySQL/MariaDB database
+- A configured **MySQL 8.0.13+** or **MariaDB 10.2.7+** database
+    - MariaDB LTS (`mariadb:lts`) is the recommended and most-tested deployment target
 
 ## Quickstart
 

--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -1,5 +1,7 @@
 ## Common Config ##
 
+# Supported: MySQL 8.0.13+ or MariaDB 10.2.7+
+# Recommended: MariaDB LTS
 database: # database
   host: localhost # database host [DATABASE__HOST]
   port: 3306 # database port [DATABASE__PORT]

--- a/deployments/docker-compose/docker-compose.yml
+++ b/deployments/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         condition: service_healthy
 
   db:
-    image: mariadb:lts
+    image: mariadb:lts # MariaDB LTS - minimum required: 10.2.7
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=sms

--- a/deployments/helm-chart/README.md
+++ b/deployments/helm-chart/README.md
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the SMSGate chart and t
 
 ### Using an External Database
 
-To use an external database instead of the built-in MariaDB:
+To use an external database (MySQL 8.0.13+ or MariaDB 10.2.7+) instead of the built-in MariaDB:
 
 ```yaml
 database:

--- a/internal/sms-gateway/models/migrations/mysql/20260507035019_device_sim_cards.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260507035019_device_sim_cards.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE `devices`
-ADD `sim_cards` json NOT NULL DEFAULT '[]';
+ADD `sim_cards` json NOT NULL DEFAULT ('[]');
 -- +goose StatementEnd
 ---
 -- +goose Down


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified minimum supported database versions (MySQL 5.7.8+ or MariaDB 10.2.7+) across documentation and configuration examples
  * Recommended MariaDB LTS as the preferred deployment target
  
* **Chores**
  * Updated deployment and configuration documentation to reflect database compatibility requirements
  * Database schema migration for enhanced data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->