### PR TITLE
[settings] add work hours support

### DIFF
--- a/internal/sms-gateway/modules/settings/utils.go
+++ b/internal/sms-gateway/modules/settings/utils.go
@@ -22,6 +22,9 @@ var (
 			"limit_value":        "",
 			"sim_selection_mode": "",
 			"log_lifetime_days":  "",
+			"work_hours_enabled": "",
+			"work_hours_start":   "",
+			"work_hours_end":     "",
 		},
 		"ping": map[string]any{
 			"interval_seconds": "",
@@ -51,6 +54,9 @@ var (
 			"limit_value":        "",
 			"sim_selection_mode": "",
 			"log_lifetime_days":  "",
+			"work_hours_enabled": "",
+			"work_hours_start":   "",
+			"work_hours_end":     "",
 		},
 		"ping": map[string]any{
 			"interval_seconds": "",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added settings fields for enabling work hours and defining work-hour start and end times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new fields — `work_hours_enabled`, `work_hours_start`, and `work_hours_end` — to the server-side settings allowlists in `utils.go`, enabling the existing work-hours feature in the Android client to round-trip through the server's settings API.

- Both the private (`rules`) and public (`rulesPublic`) filter maps under `messages` are updated symmetrically, so devices can both write and read these settings through the API.
- No server-side format validation is added for the time strings (`HH:mm`), consistent with the existing approach of delegating validation to the Android client's `import()` method.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, additive allowlist expansion with no behavioural side-effects on existing settings.

The three new fields are added symmetrically to both the private and public filter maps, matching the exact pattern used by every other messages setting. No existing logic is modified. The Android client already implements full validation of these values on import, and the server's pass-through approach for string fields is consistent throughout the codebase.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/modules/settings/utils.go | Adds work_hours_enabled, work_hours_start, and work_hours_end to both the private rules map and the public rulesPublic map, symmetrically with existing message settings fields. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Device as Android Device
    participant API as Server API
    participant Svc as Settings Service
    participant DB as Database

    Device->>API: PUT /settings (work_hours_enabled, work_hours_start, work_hours_end)
    API->>Svc: UpdateSettings(userID, payload)
    Svc->>Svc: filterMap(payload, rules)
    Note over Svc: rules now includes work_hours_* fields
    Svc->>DB: Upsert filtered settings
    DB-->>Svc: Updated settings
    Svc->>Svc: filterMap(updated, rulesPublic)
    Note over Svc: rulesPublic also includes work_hours_* fields
    Svc-->>API: Public settings map
    API-->>Device: "200 OK (settings incl. work_hours_*)"

    Device->>API: GET /settings
    API->>Svc: "GetSettings(userID, public=true)"
    Svc->>DB: Fetch settings
    DB-->>Svc: Raw settings
    Svc->>Svc: filterMap(settings, rulesPublic)
    Svc-->>API: Filtered public settings
    API-->>Device: "200 OK (work_hours_* visible)"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["\[settings\] add work hours support"](https://github.com/android-sms-gateway/server/commit/a740bd9eda86e642434e4a0cb143713c6ba6f33d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47803636)</sub>

<!-- /greptile_comment -->