### PR TITLE
[api] add support for batch webhooks

### DIFF
--- a/api/requests.http
+++ b/api/requests.http
@@ -126,14 +126,15 @@ GET {{baseUrl}}/3rdparty/v1/messages?sort=created_at HTTP/1.1
 Authorization: Basic {{credentials}}
 
 ###
-POST {{baseUrl}}/3rdparty/v1/messages/inbox/export HTTP/1.1
+POST {{baseUrl}}/3rdparty/v1/inbox/refresh HTTP/1.1
 Authorization: Basic {{credentials}}
 Content-Type: application/json
 
 {
     "since": "2024-12-01T00:00:00.000Z",
     "until": "2024-12-31T23:59:59.999Z",
-    "deviceId": "_Py53j9Cj-JAWMqDXQcQF"
+    "deviceId": "_Py53j9Cj-JAWMqDXQcQF",
+    "webhookDelivery": "Batch"
 }
 
 ###

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.21.0
-	github.com/android-sms-gateway/client-go v1.14.4
+	github.com/android-sms-gateway/client-go v1.14.5
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/android-sms-gateway/client-go v1.14.4 h1:kFGuiyChN1zgaKVOZ29AEXRufiWjzcpDS+IFhg6NaMo=
-github.com/android-sms-gateway/client-go v1.14.4/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.14.5 h1:CtyXAHPdyDtCFTzeVPt5EUfnWhQ2RsIWbCUk52tbGjw=
+github.com/android-sms-gateway/client-go v1.14.5/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/handlers/inbox/3rdparty.go
+++ b/internal/sms-gateway/handlers/inbox/3rdparty.go
@@ -64,7 +64,7 @@ func (h *ThirdPartyController) list(_ string, _ *fiber.Ctx) error {
 }
 
 //	@Summary		Request inbox messages refresh
-//	@Description	Refreshes inbox messages. Webhooks are triggered when triggerWebhooks is true.
+//	@Description	Refreshes inbox messages. Webhook triggering depends on the `webhookDelivery` parameter.
 //	@Security		ApiAuth
 //	@Security		JWTAuth
 //	@Tags			User, Inbox
@@ -91,7 +91,7 @@ func (h *ThirdPartyController) refresh(userID string, c *fiber.Ctx) error {
 		req.Since,
 		req.Until,
 		req.MessageTypes,
-		&req.TriggerWebhooks,
+		req.ResolveWebhookDelivery(),
 	); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -292,7 +292,7 @@ func (h *ThirdPartyController) postInboxExport(userID string, c *fiber.Ctx) erro
 		req.Since,
 		req.Until,
 		[]smsgateway.IncomingMessageType{smsgateway.IncomingMessageTypeSMS},
-		lo.ToPtr(true),
+		smsgateway.WebhookDeliveryIndividual,
 	); err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 	}

--- a/internal/sms-gateway/inbox/service.go
+++ b/internal/sms-gateway/inbox/service.go
@@ -28,9 +28,9 @@ func (s *Service) Refresh(
 	deviceID *string,
 	since, until time.Time,
 	types []smsgateway.IncomingMessageType,
-	triggerWebhooks *bool,
+	webhookDelivery smsgateway.WebhookDelivery,
 ) error {
-	event := events.NewMessagesExportRequestedEvent(since, until, types, triggerWebhooks)
+	event := events.NewMessagesExportRequestedEvent(since, until, types, webhookDelivery)
 
 	if err := s.eventsSvc.Notify(userID, deviceID, event); err != nil {
 		return fmt.Errorf("failed to notify device: %w", err)

--- a/internal/sms-gateway/modules/events/events.go
+++ b/internal/sms-gateway/modules/events/events.go
@@ -20,7 +20,7 @@ func NewWebhooksUpdatedEvent() Event {
 func NewMessagesExportRequestedEvent(
 	since, until time.Time,
 	types []smsgateway.IncomingMessageType,
-	triggerWebhooks *bool,
+	webhookDelivery smsgateway.WebhookDelivery,
 ) Event {
 	data := map[string]string{
 		"since": since.Format(time.RFC3339),
@@ -32,9 +32,8 @@ func NewMessagesExportRequestedEvent(
 			",",
 		)
 	}
-	if triggerWebhooks != nil {
-		data["triggerWebhooks"] = strconv.FormatBool(*triggerWebhooks)
-	}
+	data["webhookDelivery"] = string(webhookDelivery)
+	data["triggerWebhooks"] = strconv.FormatBool(webhookDelivery != smsgateway.WebhookDeliveryDisabled)
 
 	return NewEvent(
 		smsgateway.PushMessagesExportRequested,

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -481,7 +481,7 @@ const docTemplate = `{
                         "JWTAuth": []
                     }
                 ],
-                "description": "Refreshes inbox messages. Webhooks are triggered when triggerWebhooks is true.",
+                "description": "Refreshes inbox messages. Webhook triggering depends on the ` + "`" + `webhookDelivery` + "`" + ` parameter.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1727,7 +1727,7 @@ const docTemplate = `{
                     "example": "2024-01-01T00:00:00Z"
                 },
                 "triggerWebhooks": {
-                    "description": "Indicates whether to trigger webhooks for the refreshed messages.",
+                    "description": "Deprecated: use WebhookDelivery instead. Indicates whether to trigger webhooks for the refreshed messages.",
                     "type": "boolean",
                     "example": true
                 },
@@ -1736,6 +1736,20 @@ const docTemplate = `{
                     "type": "string",
                     "format": "date-time",
                     "example": "2024-01-01T23:59:59Z"
+                },
+                "webhookDelivery": {
+                    "description": "Delivery mode for webhooks (overrides triggerWebhooks when set).",
+                    "enum": [
+                        "Disabled",
+                        "Individual",
+                        "Batch"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.WebhookDelivery"
+                        }
+                    ],
+                    "example": "Batch"
                 }
             }
         },
@@ -2499,6 +2513,29 @@ const docTemplate = `{
                 }
             }
         },
+        "smsgateway.WebhookDelivery": {
+            "type": "string",
+            "enum": [
+                "Disabled",
+                "Individual",
+                "Batch"
+            ],
+            "x-enum-comments": {
+                "WebhookDeliveryBatch": "Deliver webhooks as ordered batches.",
+                "WebhookDeliveryDisabled": "Disable webhook delivery.",
+                "WebhookDeliveryIndividual": "Deliver webhooks individually (one per message)."
+            },
+            "x-enum-descriptions": [
+                "Disable webhook delivery.",
+                "Deliver webhooks individually (one per message).",
+                "Deliver webhooks as ordered batches."
+            ],
+            "x-enum-varnames": [
+                "WebhookDeliveryDisabled",
+                "WebhookDeliveryIndividual",
+                "WebhookDeliveryBatch"
+            ]
+        },
         "smsgateway.WebhookEvent": {
             "type": "string",
             "enum": [
@@ -2511,12 +2548,20 @@ const docTemplate = `{
                 "system:ping",
                 "mms:received",
                 "mms:downloaded",
-                "app:started"
+                "app:started",
+                "sms:batch:received",
+                "sms:batch:data-received",
+                "mms:batch:received",
+                "mms:batch:downloaded"
             ],
             "x-enum-comments": {
                 "WebhookEventAppStarted": "Triggered when the application is started.",
+                "WebhookEventMmsBatchDownloaded": "Triggered when a batch of MMS messages is downloaded.",
+                "WebhookEventMmsBatchReceived": "Triggered when a batch of MMS messages is received.",
                 "WebhookEventMmsDownloaded": "Triggered when an MMS is downloaded.",
                 "WebhookEventMmsReceived": "Triggered when an MMS is received.",
+                "WebhookEventSmsBatchDataReceived": "Triggered when a batch of data SMS messages is received.",
+                "WebhookEventSmsBatchReceived": "Triggered when a batch of SMS messages is received.",
                 "WebhookEventSmsCancelled": "Triggered when an SMS is cancelled.",
                 "WebhookEventSmsDataReceived": "Triggered when a data SMS is received.",
                 "WebhookEventSmsDelivered": "Triggered when an SMS is delivered.",
@@ -2535,7 +2580,11 @@ const docTemplate = `{
                 "Triggered when the device pings the server.",
                 "Triggered when an MMS is received.",
                 "Triggered when an MMS is downloaded.",
-                "Triggered when the application is started."
+                "Triggered when the application is started.",
+                "Triggered when a batch of SMS messages is received.",
+                "Triggered when a batch of data SMS messages is received.",
+                "Triggered when a batch of MMS messages is received.",
+                "Triggered when a batch of MMS messages is downloaded."
             ],
             "x-enum-varnames": [
                 "WebhookEventSmsReceived",
@@ -2547,7 +2596,11 @@ const docTemplate = `{
                 "WebhookEventSystemPing",
                 "WebhookEventMmsReceived",
                 "WebhookEventMmsDownloaded",
-                "WebhookEventAppStarted"
+                "WebhookEventAppStarted",
+                "WebhookEventSmsBatchReceived",
+                "WebhookEventSmsBatchDataReceived",
+                "WebhookEventMmsBatchReceived",
+                "WebhookEventMmsBatchDownloaded"
             ]
         }
     },

--- a/test/e2e/inbox_refresh_test.go
+++ b/test/e2e/inbox_refresh_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestInboxRefresh_WebhookDelivery(t *testing.T) {
+	credentials := mobileDeviceRegister(t, publicMobileClient)
+	authorizedClient := publicUserClient.Clone().SetBasicAuth(credentials.Login, credentials.Password)
+
+	type inboxRefreshRequest struct {
+		Since           string  `json:"since"`
+		Until           string  `json:"until"`
+		WebhookDelivery *string `json:"webhookDelivery,omitempty"`
+		TriggerWebhooks *bool   `json:"triggerWebhooks,omitempty"`
+	}
+
+	cases := []struct {
+		name               string
+		body               inboxRefreshRequest
+		expectedStatusCode int
+	}{
+		{
+			name: "webhookDelivery Individual",
+			body: inboxRefreshRequest{
+				Since:           "2024-01-01T00:00:00Z",
+				Until:           "2024-01-01T23:59:59Z",
+				WebhookDelivery: ptr("Individual"),
+			},
+			expectedStatusCode: 202,
+		},
+		{
+			name: "webhookDelivery Batch",
+			body: inboxRefreshRequest{
+				Since:           "2024-01-01T00:00:00Z",
+				Until:           "2024-01-01T23:59:59Z",
+				WebhookDelivery: ptr("Batch"),
+			},
+			expectedStatusCode: 202,
+		},
+		{
+			name: "webhookDelivery Disabled",
+			body: inboxRefreshRequest{
+				Since:           "2024-01-01T00:00:00Z",
+				Until:           "2024-01-01T23:59:59Z",
+				WebhookDelivery: ptr("Disabled"),
+			},
+			expectedStatusCode: 202,
+		},
+		{
+			name: "legacy triggerWebhooks true",
+			body: inboxRefreshRequest{
+				Since:           "2024-01-01T00:00:00Z",
+				Until:           "2024-01-01T23:59:59Z",
+				TriggerWebhooks: ptr(true),
+			},
+			expectedStatusCode: 202,
+		},
+		{
+			name: "legacy triggerWebhooks false",
+			body: inboxRefreshRequest{
+				Since:           "2024-01-01T00:00:00Z",
+				Until:           "2024-01-01T23:59:59Z",
+				TriggerWebhooks: ptr(false),
+			},
+			expectedStatusCode: 202,
+		},
+		{
+			name: "webhookDelivery takes precedence over triggerWebhooks",
+			body: inboxRefreshRequest{
+				Since:           "2024-01-01T00:00:00Z",
+				Until:           "2024-01-01T23:59:59Z",
+				WebhookDelivery: ptr("Batch"),
+				TriggerWebhooks: ptr(false),
+			},
+			expectedStatusCode: 202,
+		},
+		{
+			name: "neither webhookDelivery nor triggerWebhooks provided",
+			body: inboxRefreshRequest{
+				Since: "2024-01-01T00:00:00Z",
+				Until: "2024-01-01T23:59:59Z",
+			},
+			expectedStatusCode: 202,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := authorizedClient.R().
+				SetBody(c.body).
+				Post("inbox/refresh")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode() != c.expectedStatusCode {
+				t.Fatalf("expected %d, got %d: %s", c.expectedStatusCode, res.StatusCode(), res.String())
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/test/e2e/webhooks_test.go
+++ b/test/e2e/webhooks_test.go
@@ -496,6 +496,60 @@ func TestWebhooks_Post(t *testing.T) {
 	}
 }
 
+func TestWebhooks_Post_BatchEventTypes(t *testing.T) {
+	credentials := mobileDeviceRegister(t, publicMobileClient)
+	authorizedClient := publicUserClient.Clone().SetBasicAuth(credentials.Login, credentials.Password)
+
+	batchEvents := []struct {
+		event       string
+		description string
+	}{
+		{"sms:batch:received", "SMS Batch Received"},
+		{"sms:batch:data-received", "Data SMS Batch Received"},
+		{"mms:batch:received", "MMS Batch Received"},
+		{"mms:batch:downloaded", "MMS Batch Downloaded"},
+	}
+
+	for _, be := range batchEvents {
+		t.Run(be.description, func(t *testing.T) {
+			resp, err := authorizedClient.R().
+				SetBody(webhook{
+					URL:   "https://example.com/batch-webhook",
+					Event: be.event,
+				}).Post("webhooks")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if resp.StatusCode() != 201 {
+				t.Fatalf("expected 201 for event %s, got %d: %s", be.event, resp.StatusCode(), resp.String())
+			}
+
+			var result webhook
+			if err := json.Unmarshal(resp.Body(), &result); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Cleanup(func() {
+				_, err := authorizedClient.R().Delete("webhooks/" + result.ID)
+				if err != nil {
+					t.Error(err)
+				}
+			})
+
+			if result.ID == "" {
+				t.Error("webhook ID is empty")
+			}
+			if result.Event != be.event {
+				t.Errorf("expected event '%s', got '%s'", be.event, result.Event)
+			}
+			if result.URL != "https://example.com/batch-webhook" {
+				t.Errorf("expected URL 'https://example.com/batch-webhook', got '%s'", result.URL)
+			}
+		})
+	}
+}
+
 func TestWebhooks_Delete(t *testing.T) {
 	credentials := mobileDeviceRegister(t, publicMobileClient)
 	authorizedClient := publicUserClient.Clone().SetBasicAuth(credentials.Login, credentials.Password)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `webhookDelivery` modes for inbox refresh/message export: `Disabled`, `Individual`, and `Batch`.
  * Expanded webhook event variants with additional batch-related cases.
* **Bug Fixes**
  * Webhook triggering behavior now consistently follows `webhookDelivery`; legacy `triggerWebhooks` is deprecated.
* **Documentation**
  * Updated the generated OpenAPI/Swagger spec to document `webhookDelivery`, including its schema and deprecations.
* **Tests**
  * Added end-to-end coverage for `inbox/refresh` webhook delivery combinations and batch webhook event posting.
* **Chores**
  * Updated a Go dependency and refreshed generated API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces batch webhook delivery support for inbox refresh and message export operations, replacing the old `*bool` `triggerWebhooks` parameter with a typed `WebhookDelivery` enum (`Disabled`, `Individual`, `Batch`) sourced from `client-go` v1.14.5. Backward compatibility is preserved by continuing to emit the `triggerWebhooks` key in push event data (derived from the resolved delivery mode), so older Android app versions keep working.

- `events.go` now unconditionally writes both `webhookDelivery` and `triggerWebhooks` to the push event payload; the deprecated `/messages/inbox/export` endpoint maps to `WebhookDeliveryIndividual`, preserving the old always-trigger behavior.
- Four new batch webhook event types (`sms:batch:received`, `sms:batch:data-received`, `mms:batch:received`, `mms:batch:downloaded`) are registered in the OpenAPI spec.
- E2e tests cover all `webhookDelivery` enum values, the legacy `triggerWebhooks` bool, combined precedence, and the default (neither field provided) case.

<h3>Confidence Score: 5/5</h3>

- The change is safe to merge: it replaces a raw boolean pointer with a well-typed enum while emitting both the new and legacy push-event keys, so existing Android clients remain unaffected.
- The refactoring is narrowly scoped to the webhook delivery path, backward compat is explicitly maintained by always writing triggerWebhooks into the event data, and both legacy and new code paths have e2e coverage. No data is dropped, no auth boundary is crossed, and the dependency bump is to a tagged release.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/modules/events/events.go | Replaces the optional `*bool` triggerWebhooks parameter with a typed `WebhookDelivery` enum; both `webhookDelivery` and `triggerWebhooks` are now always written to the event data map, preserving backward compat for older Android app versions. |
| internal/sms-gateway/handlers/inbox/3rdparty.go | Calls `req.ResolveWebhookDelivery()` from the updated client-go library instead of taking the address of the raw `TriggerWebhooks` bool; API description updated to reflect the new `webhookDelivery` parameter. |
| internal/sms-gateway/handlers/messages/3rdparty.go | Deprecated `postInboxExport` now passes `WebhookDeliveryIndividual` instead of `lo.ToPtr(true)`, preserving the previous always-trigger-webhooks behavior while adopting the new typed enum. |
| test/e2e/inbox_refresh_test.go | New e2e test for `/inbox/refresh` covering all `webhookDelivery` enum values, legacy `triggerWebhooks` bool, combined precedence, and the "neither provided" default; introduces a generic `ptr` helper that is unique to this file in the package. |
| test/e2e/webhooks_test.go | Adds `TestWebhooks_Post_BatchEventTypes` covering all four new batch event type strings; cleanup via `t.Cleanup` is correctly registered even in subtests. |
| go.mod | Bumps `client-go` from v1.14.4 to v1.14.5 (tagged release); go.sum updated accordingly. The previous pseudo-version concern from an earlier review no longer applies. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as API Client
    participant Handler as inbox Handler
    participant InboxSvc as inbox.Service
    participant Events as events Module
    participant Device as Android Device

    Client->>Handler: "POST /inbox/refresh {webhookDelivery or triggerWebhooks}"
    Handler->>Handler: req.ResolveWebhookDelivery()
    Handler->>InboxSvc: Refresh(userID, since, until, types, webhookDelivery)
    InboxSvc->>Events: NewMessagesExportRequestedEvent(since, until, types, webhookDelivery)
    Events->>Events: set webhookDelivery and triggerWebhooks in data map
    Events-->>InboxSvc: "Event{PushMessagesExportRequested, data}"
    InboxSvc->>Device: Push notification
    Handler-->>Client: 202 Accepted
```
</details>

<sub>Reviews (12): Last reviewed commit: ["\[api\] add support for batch webhooks"](https://github.com/android-sms-gateway/server/commit/c72155f15a87920861f26030cfcc3f32ed6b8474) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47803633)</sub>

<!-- /greptile_comment -->