### PR TITLE
[api] use `ListMessagesOptions` from `client-go`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.20.0
-	github.com/android-sms-gateway/client-go v1.14.1
+	github.com/android-sms-gateway/client-go v1.14.2
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,10 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/android-sms-gateway/client-go v1.14.1 h1:XKHq81sWSB/HBEWN3/5ejsLLDdKx3YMirDe44Vq6h8E=
-github.com/android-sms-gateway/client-go v1.14.1/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.14.2-0.20260709042807-8ba7e823fdcf h1:QioVLKlDba/1EJiT9a8nXvUlVT2OTDwH+R8JzYGlGNw=
+github.com/android-sms-gateway/client-go v1.14.2-0.20260709042807-8ba7e823fdcf/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.14.2 h1:WlYqijdyRe+35b6Bz4iTMJz5DalEgxLPNvnhnQwUvMI=
+github.com/android-sms-gateway/client-go v1.14.2/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -1,9 +1,7 @@
 package messages
 
 import (
-	"errors"
-	"time"
-
+	"github.com/android-sms-gateway/client-go/smsgateway"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
 )
 
@@ -12,45 +10,25 @@ type thirdPartyPostQueryParams struct {
 	DeviceActiveWithin  int  `query:"deviceActiveWithin"  validate:"omitempty,min=1"`
 }
 
-type thirdPartyGetQueryParams struct {
-	StartDate      string `query:"from"           validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
-	EndDate        string `query:"to"             validate:"omitempty,datetime=2006-01-02T15:04:05Z07:00"`
-	State          string `query:"state"          validate:"omitempty,oneof=Pending Cancelling Cancelled Processed Sent Delivered Failed"`
-	DeviceID       string `query:"deviceId"       validate:"omitempty,len=21"`
-	Limit          int    `query:"limit"          validate:"omitempty,min=1,max=100"`
-	Offset         int    `query:"offset"         validate:"omitempty,min=0"`
-	IncludeContent bool   `query:"includeContent"`
-}
-
-func (p *thirdPartyGetQueryParams) Validate() error {
-	if p.StartDate != "" && p.EndDate != "" && p.StartDate > p.EndDate {
-		return errors.New("`from` date must be before `to` date") //nolint:err113 // won't be used directly
-	}
-
-	return nil
-}
+type thirdPartyGetQueryParams smsgateway.ListMessagesOptions
 
 func (p *thirdPartyGetQueryParams) ToFilter() messages.SelectFilter {
 	var filter messages.SelectFilter
 
-	if p.StartDate != "" {
-		if t, err := time.Parse(time.RFC3339, p.StartDate); err == nil {
-			filter.StartDate = t
-		}
+	if p.From != nil {
+		filter.StartDate = *p.From
 	}
 
-	if p.EndDate != "" {
-		if t, err := time.Parse(time.RFC3339, p.EndDate); err == nil {
-			filter.EndDate = t
-		}
+	if p.To != nil {
+		filter.EndDate = *p.To
 	}
 
-	if p.State != "" {
-		filter.State = append(filter.State, messages.ProcessingState(p.State))
+	if p.State != nil {
+		filter.State = append(filter.State, messages.ProcessingState(*p.State))
 	}
 
-	if p.DeviceID != "" {
-		filter.DeviceID = p.DeviceID
+	if p.DeviceID != nil {
+		filter.DeviceID = *p.DeviceID
 	}
 
 	return filter
@@ -62,16 +40,19 @@ func (p *thirdPartyGetQueryParams) ToOptions() messages.SelectOptions {
 	var options messages.SelectOptions
 	options.WithRecipients = true
 	options.WithStates = true
-	options.WithContent = p.IncludeContent
 
-	if p.Limit > 0 {
-		options.Limit = min(p.Limit, maxLimit)
+	if p.IncludeContent != nil {
+		options.WithContent = *p.IncludeContent
+	}
+
+	if p.Limit != nil {
+		options.Limit = min(*p.Limit, maxLimit)
 	} else {
 		options.Limit = 50
 	}
 
-	if p.Offset > 0 {
-		options.Offset = p.Offset
+	if p.Offset != nil {
+		options.Offset = max(*p.Offset, 0)
 	}
 
 	return options


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message-list query handling and filtering to better respect provided parameters.
  * Optional message content, limit, and offset are now applied consistently.
  * Message `limit` defaults to 50 when omitted and is capped at 100.
  * `offset` now defaults to 0 and can’t be negative.
* **Chores**
  * Updated the SMS gateway client dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->