### PR TITLE
[messages] add sort order option

### DIFF
--- a/api/requests.http
+++ b/api/requests.http
@@ -122,6 +122,10 @@ GET {{baseUrl}}/3rdparty/v1/messages?from=2025-01-01T00:00:00.000Z&to=2025-12-31
 Authorization: Basic {{credentials}}
 
 ###
+GET {{baseUrl}}/3rdparty/v1/messages?sort=created_at HTTP/1.1
+Authorization: Basic {{credentials}}
+
+###
 POST {{baseUrl}}/3rdparty/v1/messages/inbox/export HTTP/1.1
 Authorization: Basic {{credentials}}
 Content-Type: application/json

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.21.0
-	github.com/android-sms-gateway/client-go v1.14.2
+	github.com/android-sms-gateway/client-go v1.14.3
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/android-sms-gateway/client-go v1.14.2 h1:WlYqijdyRe+35b6Bz4iTMJz5DalEgxLPNvnhnQwUvMI=
-github.com/android-sms-gateway/client-go v1.14.2/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.14.3 h1:Yqg2tkztri8ruDU3LTO+TVQYdT3JyM/rVMaeeKgWKn8=
+github.com/android-sms-gateway/client-go v1.14.3/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -181,13 +181,14 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 //	@Security		JWTAuth
 //	@Tags			User, Messages
 //	@Produce		json
-//	@Param			from			query		string							false	"Start date in RFC3339 format"													Format(date-time)
-//	@Param			to				query		string							false	"End date in RFC3339 format"													Format(date-time)
-//	@Param			state			query		string							false	"Filter messages by processing state"											Enum(Pending, Processed, Sent, Delivered, Failed)
-//	@Param			deviceId		query		string							false	"Filter by device ID"															min(21)		max(21)
-//	@Param			limit			query		int								false	"Pagination limit"																default(50)	min(1)	max(100)
-//	@Param			offset			query		int								false	"Pagination offset"																default(0)
-//	@Param			includeContent	query		bool							false	"Include textMessage/dataMessage content for each message. Default is false"	default(false)
+//	@Param			from			query		string							false	"Start date in RFC3339 format"															Format(date-time)
+//	@Param			to				query		string							false	"End date in RFC3339 format"															Format(date-time)
+//	@Param			state			query		string							false	"Filter messages by processing state"													Enum(Pending, Processed, Sent, Delivered, Failed)
+//	@Param			deviceId		query		string							false	"Filter by device ID"																	min(21)		max(21)
+//	@Param			limit			query		int								false	"Pagination limit"																		default(50)	min(1)	max(100)
+//	@Param			offset			query		int								false	"Pagination offset"																		default(0)
+//	@Param			includeContent	query		bool							false	"Include textMessage/dataMessage content for each message. Default is false"			default(false)
+//	@Param			sort			query		string							false	"Sort order per JSON:API spec. Use created_at (ascending) or -created_at (descending)"	Enums(created_at, -created_at)	default(-created_at)
 //	@Success		200				{object}	smsgateway.GetMessagesResponse	"A list of messages"
 //	@Header			200				{integer}	X-Total-Count					"Total number of items available"
 //	@Failure		400				{object}	smsgateway.ErrorResponse		"Invalid request"
@@ -201,6 +202,10 @@ func (h *ThirdPartyController) list(userID string, c *fiber.Ctx) error {
 	params := new(thirdPartyGetQueryParams)
 	if err := h.QueryParserValidator(c, params); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	if params.Sort == nil {
+		params.Sort = lo.ToPtr(smsgateway.CreatedAtDescending)
 	}
 
 	messages, total, err := h.messagesSvc.SelectStates(userID, params.ToFilter(), params.ToOptions())

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -46,13 +46,22 @@ func (p *thirdPartyGetQueryParams) ToOptions() messages.SelectOptions {
 	}
 
 	if p.Limit != nil {
-		options.Limit = min(*p.Limit, maxLimit)
+		options.Limit = max(min(*p.Limit, maxLimit), 1)
 	} else {
 		options.Limit = 50
 	}
 
 	if p.Offset != nil {
 		options.Offset = max(*p.Offset, 0)
+	}
+
+	if p.Sort != nil {
+		switch *p.Sort {
+		case smsgateway.CreatedAtAscending:
+			options.SortField = messages.SortFieldCreatedAtAsc
+		case smsgateway.CreatedAtDescending:
+			options.SortField = messages.SortFieldCreatedAtDesc
+		}
 	}
 
 	return options

--- a/internal/sms-gateway/modules/messages/repository.go
+++ b/internal/sms-gateway/modules/messages/repository.go
@@ -71,9 +71,14 @@ func (r *Repository) list(filter SelectFilter, options SelectOptions) ([]message
 	}
 
 	// Apply ordering
-	if options.OrderBy == MessagesOrderFIFO {
+	switch {
+	case options.SortField == SortFieldCreatedAtAsc:
+		query = query.Order("messages.created_at ASC, messages.id ASC")
+	case options.SortField == SortFieldCreatedAtDesc:
+		query = query.Order("messages.created_at DESC, messages.id DESC")
+	case options.OrderBy == MessagesOrderFIFO:
 		query = query.Order("messages.schedule_at ASC, messages.priority DESC, messages.id ASC")
-	} else {
+	default:
 		query = query.Order("messages.schedule_at ASC, messages.priority DESC, messages.id DESC")
 	}
 

--- a/internal/sms-gateway/modules/messages/repository_filter.go
+++ b/internal/sms-gateway/modules/messages/repository_filter.go
@@ -13,6 +13,19 @@ const (
 	MessagesOrderFIFO Order = "fifo"
 )
 
+// SortField defines the allowed column sort directions.
+// Only values defined here may be used in SelectOptions.SortField.
+type SortField string
+
+const (
+	// SortFieldNone is the zero value (no explicit sort; falls through to OrderBy/default).
+	SortFieldNone SortField = ""
+	// SortFieldCreatedAtAsc sorts by created_at ascending.
+	SortFieldCreatedAtAsc SortField = "created_at_asc"
+	// SortFieldCreatedAtDesc sorts by created_at descending.
+	SortFieldCreatedAtDesc SortField = "created_at_desc"
+)
+
 type SelectFilter struct {
 	ExtID     string
 	UserID    string
@@ -57,6 +70,10 @@ type SelectOptions struct {
 	// OrderBy sets the retrieval order for pending messages.
 	// Empty (zero) value defaults to "lifo".
 	OrderBy Order
+
+	// SortField selects a column sort direction.
+	// When non-zero, it overrides OrderBy.
+	SortField SortField
 
 	Limit  int
 	Offset int

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -673,6 +673,17 @@ const docTemplate = `{
                         "description": "Include textMessage/dataMessage content for each message. Default is false",
                         "name": "includeContent",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "created_at",
+                            "-created_at"
+                        ],
+                        "type": "string",
+                        "default": "-created_at",
+                        "description": "Sort order per JSON:API spec. Use created_at (ascending) or -created_at (descending)",
+                        "name": "sort",
+                        "in": "query"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sort=created_at` / `sort=-created_at` to the 3rd-party messages endpoint, defaulting to newest-first.
  * Extended device settings with work-hours configuration (enabled, start, end).

* **Bug Fixes**
  * Enforced a minimum `limit` of 1 when provided.
  * Applied the requested sort consistently and made `created_at`-based sorting take priority over previous ordering rules.

* **Documentation**
  * Updated Swagger/OpenAPI and the 3rd-party messages request example to reflect the new sorted listing call.

* **Chores**
  * Updated a Go client dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `sort` query parameter (`created_at` / `-created_at`) to the 3rd-party messages listing endpoint, defaulting to `-created_at` (newest-first). It also fixes a pre-existing bug where passing `?limit=0` silently bypassed pagination.

- **Sort feature:** A new `SortField` enum is introduced in the repository layer with safe, opaque constant values, and the repository's `list()` switch evaluates `SortField` before the legacy `OrderBy`, so existing internal callers (e.g., `listPending`) are unaffected.
- **Default sort change:** When no `sort` parameter is supplied, the handler now injects `-created_at` as the default, replacing the old implicit `schedule_at ASC, priority DESC, id DESC` ordering. This is a deliberate behavior change for existing 3rd-party API consumers who omit the parameter — documented in the PR description.
- **Limit fix:** `max(min(*p.Limit, maxLimit), 1)` correctly prevents `?limit=0` from bypassing the `Limit > 0` guard in the repository, which would otherwise return all rows.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new sort parameter is fully validated, the repository ordering logic is correctly prioritized, and existing callers are unaffected.

All changed paths are well-guarded: sort values are constrained by oneof validation before reaching the switch, the SortField constants are opaque internal strings (not raw SQL), the repository falls through correctly for callers that don't set SortField, and the limit-minimum fix closes a real bypass. The dependency bump is now a proper tagged release.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/handlers/messages/3rdparty.go | Adds swagger annotation for sort param and injects -created_at default when sort is omitted; logic is correct and the nil-guard runs before ToOptions(). |
| internal/sms-gateway/handlers/messages/params.go | Maps validated sort param to SortField constants and enforces limit >= 1; both changes are correct. |
| internal/sms-gateway/modules/messages/repository.go | Replaces if/else OrderBy check with a switch that evaluates SortField first; existing callers that don't set SortField fall through correctly to the OrderBy cases. |
| internal/sms-gateway/modules/messages/repository_filter.go | Introduces SortField type with opaque constants (not raw SQL strings) and adds SortField field to SelectOptions; safe and well-documented. |
| go.mod | Bumps client-go from v1.14.2 to v1.14.3, a proper tagged release; the pseudo-version concern from the earlier review thread is resolved. |
| internal/sms-gateway/openapi/docs.go | Auto-generated OpenAPI spec updated to reflect the new sort parameter with correct enum values and default. |
| api/requests.http | Adds an example request exercising the new sort param; no issues. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as ThirdPartyController.list
    participant Params as thirdPartyGetQueryParams
    participant Repo as Repository.list

    Client->>Handler: "GET /3rdparty/v1/messages?sort=created_at"
    Handler->>Params: QueryParserValidator (validate oneof)
    alt sort param absent
        Handler->>Params: "Sort = &"-created_at" (default)"
    end
    Handler->>Params: ToFilter()
    Handler->>Params: ToOptions()
    Note over Params: switch *Sort
    Params-->>Handler: "SelectFilter, SelectOptions{SortField}"
    Handler->>Repo: SelectStates(userID, filter, options)
    Note over Repo: SortField drives ORDER BY
    Repo-->>Handler: messages, total
    Handler-->>Client: 200 JSON + X-Total-Count
```
</details>

<sub>Reviews (4): Last reviewed commit: ["\[messages\] add sort order option"](https://github.com/android-sms-gateway/server/commit/a3edc86373cfb3070a20dd322ac64d31f345026c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47803627)</sub>

<!-- /greptile_comment -->