### PR TITLE
[otp] decrease TTL and use alnum characters

### DIFF
--- a/configs/config.example.yml
+++ b/configs/config.example.yml
@@ -47,7 +47,9 @@ jwt:
   refresh_ttl: 720h # refresh token ttl [JWT__REFRESH_TTL]
   issuer: # jwt issuer [JWT__ISSUER]
 otp: # otp config
-  ttl: 300 # otp ttl in seconds [OTP__TTL]
+  enabled: true # enable one-time code authentication for device registration [OTP__ENABLED]
+  length: 6 # otp code length (min 6) [OTP__LENGTH]
+  ttl: 60 # otp ttl in seconds [OTP__TTL]
   retries: 3 # otp generation retries (collision handling) [OTP__RETRIES]
 
 ## Worker Config ##

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,8 +109,10 @@ type JWT struct {
 }
 
 type OTP struct {
-	TTL     uint16 `yaml:"ttl"     envconfig:"OTP__TTL"`
-	Retries uint8  `yaml:"retries" envconfig:"OTP__RETRIES"`
+	Enabled bool   `yaml:"enabled" envconfig:"OTP__ENABLED"` // enable one-time code authentication for device registration
+	Length  uint8  `yaml:"length"  envconfig:"OTP__LENGTH"`  // OTP code length (min 6)
+	TTL     uint16 `yaml:"ttl"     envconfig:"OTP__TTL"`     // otp ttl in seconds
+	Retries uint8  `yaml:"retries" envconfig:"OTP__RETRIES"` // otp generation retries (collision handling)
 }
 
 func Default() Config {
@@ -163,7 +165,9 @@ func Default() Config {
 			Issuer:     "sms-gate.app",
 		},
 		OTP: OTP{
-			TTL:     300,
+			Enabled: true,
+			Length:  6,
+			TTL:     60,
 			Retries: 3,
 		},
 	}

--- a/internal/config/module.go
+++ b/internal/config/module.go
@@ -159,6 +159,8 @@ func Module() fx.Option {
 		}),
 		fx.Provide(func(cfg Config) otp.Config {
 			return otp.Config{
+				Enabled: cfg.OTP.Enabled,
+				Length:  int(cfg.OTP.Length),
 				TTL:     time.Duration(cfg.OTP.TTL) * time.Second,
 				Retries: int(cfg.OTP.Retries),
 			}

--- a/internal/sms-gateway/handlers/mobile.go
+++ b/internal/sms-gateway/handlers/mobile.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/webhooks"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/auth"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/devices"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/otp"
 	"github.com/android-sms-gateway/server/internal/sms-gateway/users"
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
@@ -74,7 +76,7 @@ func newMobileHandler(
 }
 
 func (h *mobileHandler) Register(router fiber.Router) {
-	router = router.Group("/mobile/v1")
+	router = router.Group("/mobile/v1", h.errorsHandler)
 
 	router.Post("/device",
 		userauth.NewBasic(h.usersSvc),
@@ -255,14 +257,14 @@ func (h *mobileHandler) patchDevice(device devices.Device, c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	smsgateway.MobileUserCodeResponse	"User code"
 //	@Failure		500	{object}	smsgateway.ErrorResponse			"Internal server error"
+//	@Failure		501	{object}	smsgateway.ErrorResponse			"OTP service disabled"
 //	@Router			/mobile/v1/user/code [get]
 //
 // Get user code.
 func (h *mobileHandler) getUserCode(userID string, c *fiber.Ctx) error {
 	code, err := h.authSvc.GenerateUserCode(c.Context(), userID)
 	if err != nil {
-		h.Logger.Error("failed to generate user code", zap.Error(err), zap.String("user_id", userID))
-		return fiber.NewError(fiber.StatusInternalServerError, "failed to generate user code")
+		return fmt.Errorf("failed to generate user code: %w", err)
 	}
 
 	return c.JSON(smsgateway.MobileUserCodeResponse{
@@ -310,4 +312,22 @@ func (h *mobileHandler) simCardsToDomain(simCards []smsgateway.SimCard) []device
 			ICCID:       sc.ICCID,
 		}
 	})
+}
+
+func (h *mobileHandler) errorsHandler(c *fiber.Ctx) error {
+	err := c.Next()
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, otp.ErrInvalidConfig):
+		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	case errors.Is(err, otp.ErrInitFailed):
+		return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+	case errors.Is(err, otp.ErrDisabled):
+		return fiber.NewError(fiber.StatusNotImplemented, err.Error())
+	}
+
+	return err //nolint:wrapcheck // passed through to fiber's error handler
 }

--- a/internal/sms-gateway/otp/config.go
+++ b/internal/sms-gateway/otp/config.go
@@ -5,13 +5,21 @@ import (
 	"time"
 )
 
+const minLength = 6
+
 // Config configures the OTP service.
 type Config struct {
+	Enabled bool          `yaml:"enabled" envconfig:"OTP__ENABLED"`
+	Length  int           `yaml:"length"  envconfig:"OTP__LENGTH"`
 	TTL     time.Duration `yaml:"ttl"     envconfig:"OTP__TTL"`
 	Retries int           `yaml:"retries" envconfig:"OTP__RETRIES"`
 }
 
 func (c Config) Validate() error {
+	if c.Length < minLength {
+		return fmt.Errorf("%w: length must be at least %d", ErrInvalidConfig, minLength)
+	}
+
 	if c.TTL <= 0 {
 		return fmt.Errorf("%w: TTL must be greater than 0", ErrInvalidConfig)
 	}

--- a/internal/sms-gateway/otp/errors.go
+++ b/internal/sms-gateway/otp/errors.go
@@ -7,4 +7,6 @@ var (
 	ErrInvalidConfig = errors.New("invalid config")
 	// ErrInitFailed indicates that the OTP service failed to initialize.
 	ErrInitFailed = errors.New("initialization failed")
+	// ErrDisabled indicates that the OTP service is disabled.
+	ErrDisabled = errors.New("otp disabled")
 )

--- a/internal/sms-gateway/otp/service.go
+++ b/internal/sms-gateway/otp/service.go
@@ -2,18 +2,24 @@ package otp
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
-	"math/big"
+	"strings"
 	"time"
 
 	"github.com/go-core-fx/cachefx/cache"
+	"github.com/jaevor/go-nanoid"
 	"go.uber.org/zap"
 )
+
+// otpAlphabet contains 31 ASCII characters for OTP generation.
+// Digits 2-9 (excludes 0, 1) and letters a-z excluding i, l, o
+// (visually similar to 1, I, O/0 respectively).
+const otpAlphabet = "23456789abcdefghjkmnpqrstuvwxyz"
 
 type Service struct {
 	cfg Config
 
+	gen     func() string
 	storage *Storage
 
 	logger *zap.Logger
@@ -40,7 +46,12 @@ func NewService(cfg Config, storage *Storage, logger *zap.Logger) (*Service, err
 		return nil, fmt.Errorf("%w: logger is required", ErrInitFailed)
 	}
 
-	return &Service{cfg: cfg, storage: storage, logger: logger}, nil
+	gen, err := nanoid.CustomASCII(otpAlphabet, cfg.Length)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to create OTP generator: %w", ErrInitFailed, err)
+	}
+
+	return &Service{cfg: cfg, gen: gen, storage: storage, logger: logger}, nil
 }
 
 // Generate generates a new one-time user authorization code.
@@ -52,7 +63,9 @@ func NewService(cfg Config, storage *Storage, logger *zap.Logger) (*Service, err
 //
 // The generated code is stored with a TTL of the configured duration.
 func (s *Service) Generate(ctx context.Context, userID string) (*Code, error) {
-	const maxValue = 1000000
+	if !s.cfg.Enabled {
+		return nil, ErrDisabled
+	}
 
 	var code string
 	var err error
@@ -60,14 +73,7 @@ func (s *Service) Generate(ctx context.Context, userID string) (*Code, error) {
 	validUntil := time.Now().Add(s.cfg.TTL)
 
 	for range s.cfg.Retries {
-		num, rndErr := rand.Int(rand.Reader, big.NewInt(maxValue))
-		if rndErr != nil {
-			s.logger.Warn("failed to generate random number", zap.Error(rndErr))
-			err = rndErr
-			continue
-		}
-
-		code = fmt.Sprintf("%06d", num.Int64())
+		code = s.gen()
 
 		if err = s.storage.SetOrFail(ctx, code, userID, cache.WithValidUntil(validUntil)); err != nil {
 			s.logger.Warn("failed to store code", zap.Error(err))
@@ -94,5 +100,9 @@ func (s *Service) Generate(ctx context.Context, userID string) (*Code, error) {
 // If there is an error while validating the code, it returns the error.
 // If the code is valid, it deletes the code from the storage and returns the user ID.
 func (s *Service) Validate(ctx context.Context, code string) (string, error) {
-	return s.storage.GetAndDelete(ctx, code)
+	if !s.cfg.Enabled {
+		return "", ErrDisabled
+	}
+
+	return s.storage.GetAndDelete(ctx, strings.ToLower(code))
 }

--- a/internal/sms-gateway/otp/service_export_test.go
+++ b/internal/sms-gateway/otp/service_export_test.go
@@ -1,0 +1,5 @@
+package otp
+
+func Alphabet() string {
+	return otpAlphabet
+}

--- a/internal/sms-gateway/otp/service_test.go
+++ b/internal/sms-gateway/otp/service_test.go
@@ -1,0 +1,211 @@
+package otp_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/android-sms-gateway/server/internal/sms-gateway/otp"
+	"github.com/go-core-fx/cachefx/cache"
+	"github.com/go-playground/assert/v2"
+	"go.uber.org/zap"
+)
+
+func TestNewService(t *testing.T) {
+	storage := otp.NewStorage(cache.NewMemory(time.Hour))
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name    string
+		cfg     otp.Config
+		storage *otp.Storage
+		logger  *zap.Logger
+		wantErr error
+	}{
+		{
+			name: "valid",
+			cfg: otp.Config{
+				Enabled: true,
+				Length:  8,
+				TTL:     time.Minute,
+				Retries: 3,
+			},
+			storage: storage,
+			logger:  logger,
+		},
+		{
+			name: "nil storage",
+			cfg: otp.Config{
+				Enabled: true,
+				Length:  8,
+				TTL:     time.Minute,
+				Retries: 3,
+			},
+			storage: nil,
+			logger:  logger,
+			wantErr: otp.ErrInitFailed,
+		},
+		{
+			name: "nil logger",
+			cfg: otp.Config{
+				Enabled: true,
+				Length:  8,
+				TTL:     time.Minute,
+				Retries: 3,
+			},
+			storage: storage,
+			logger:  nil,
+			wantErr: otp.ErrInitFailed,
+		},
+		{
+			name: "invalid length",
+			cfg: otp.Config{
+				Enabled: true,
+				Length:  3,
+				TTL:     time.Minute,
+				Retries: 3,
+			},
+			storage: storage,
+			logger:  logger,
+			wantErr: otp.ErrInvalidConfig,
+		},
+		{
+			name: "zero ttl",
+			cfg: otp.Config{
+				Enabled: true,
+				Length:  8,
+				TTL:     0,
+				Retries: 3,
+			},
+			storage: storage,
+			logger:  logger,
+			wantErr: otp.ErrInvalidConfig,
+		},
+		{
+			name: "zero retries",
+			cfg: otp.Config{
+				Enabled: true,
+				Length:  8,
+				TTL:     time.Minute,
+				Retries: 0,
+			},
+			storage: storage,
+			logger:  logger,
+			wantErr: otp.ErrInvalidConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := otp.NewService(tt.cfg, tt.storage, tt.logger)
+			if tt.wantErr != nil {
+				assert.Equal(t, true, errors.Is(err, tt.wantErr))
+				assert.Equal(t, (*otp.Service)(nil), svc)
+			} else {
+				assert.Equal(t, nil, err)
+				assert.Equal(t, true, svc != nil)
+			}
+		})
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled", func(t *testing.T) {
+		svc, err := otp.NewService(
+			otp.Config{Enabled: false, Length: 8, TTL: time.Minute, Retries: 3},
+			otp.NewStorage(cache.NewMemory(time.Hour)),
+			zap.NewNop(),
+		)
+		assert.Equal(t, nil, err)
+
+		code, err := svc.Generate(ctx, "user1")
+		assert.Equal(t, otp.ErrDisabled, err)
+		assert.Equal(t, (*otp.Code)(nil), code)
+	})
+
+	t.Run("enabled code length and alphabet", func(t *testing.T) {
+		const length = 10
+		svc, err := otp.NewService(
+			otp.Config{Enabled: true, Length: length, TTL: time.Minute, Retries: 3},
+			otp.NewStorage(cache.NewMemory(time.Hour)),
+			zap.NewNop(),
+		)
+		assert.Equal(t, nil, err)
+
+		code, err := svc.Generate(ctx, "user1")
+		assert.Equal(t, nil, err)
+		assert.Equal(t, true, code != nil)
+		assert.Equal(t, length, len(code.Code))
+
+		for _, ch := range code.Code {
+			assert.Equal(t, true, strings.ContainsRune(otp.Alphabet(), ch))
+		}
+	})
+}
+
+func TestValidate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled", func(t *testing.T) {
+		svc, err := otp.NewService(
+			otp.Config{Enabled: false, Length: 8, TTL: time.Minute, Retries: 3},
+			otp.NewStorage(cache.NewMemory(time.Hour)),
+			zap.NewNop(),
+		)
+		assert.Equal(t, nil, err)
+
+		userID, err := svc.Validate(ctx, "abc123")
+		assert.Equal(t, otp.ErrDisabled, err)
+		assert.Equal(t, "", userID)
+	})
+
+	t.Run("valid code", func(t *testing.T) {
+		svc, err := otp.NewService(
+			otp.Config{Enabled: true, Length: 8, TTL: time.Minute, Retries: 3},
+			otp.NewStorage(cache.NewMemory(time.Hour)),
+			zap.NewNop(),
+		)
+		assert.Equal(t, nil, err)
+
+		code, err := svc.Generate(ctx, "user1")
+		assert.Equal(t, nil, err)
+
+		userID, err := svc.Validate(ctx, code.Code)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, "user1", userID)
+	})
+
+	t.Run("mixed case lookup", func(t *testing.T) {
+		svc, err := otp.NewService(
+			otp.Config{Enabled: true, Length: 8, TTL: time.Minute, Retries: 3},
+			otp.NewStorage(cache.NewMemory(time.Hour)),
+			zap.NewNop(),
+		)
+		assert.Equal(t, nil, err)
+
+		code, err := svc.Generate(ctx, "user1")
+		assert.Equal(t, nil, err)
+
+		upper := strings.ToUpper(code.Code)
+		userID, err := svc.Validate(ctx, upper)
+		assert.Equal(t, nil, err)
+		assert.Equal(t, "user1", userID)
+	})
+
+	t.Run("invalid code", func(t *testing.T) {
+		svc, err := otp.NewService(
+			otp.Config{Enabled: true, Length: 8, TTL: time.Minute, Retries: 3},
+			otp.NewStorage(cache.NewMemory(time.Hour)),
+			zap.NewNop(),
+		)
+		assert.Equal(t, nil, err)
+
+		userID, err := svc.Validate(ctx, "nonexistent")
+		assert.Equal(t, true, err != nil)
+		assert.Equal(t, "", userID)
+	})
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OTP enablement control and configurable code length (including a minimum length requirement).
  * OTP validation is now case-insensitive, and codes use a configurable character set.
  * Added a clear error response when OTP is disabled.
* **Bug Fixes**
  * Reduced the default OTP validity period from 300 seconds to 60 seconds.
  * Improved configuration wiring to apply the new OTP enablement and length settings consistently.
* **Documentation**
  * Updated the example configuration to reflect the new OTP settings.
* **Tests**
  * Added coverage for OTP initialization, generation, disabled behavior, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the OTP (one-time password) feature for device registration: the code generation switches from a 6-digit numeric code (crypto/rand) to an alphanumeric code using go-nanoid with a curated 31-character alphabet (digits 2–9, lowercase letters excluding visually ambiguous characters), TTL is reduced from 300 s to 60 s, validation becomes case-insensitive, and an `Enabled` toggle with a configurable `Length` field are introduced.

- OTP service gains an `Enabled` flag; disabled state is surfaced via a new `ErrDisabled` sentinel mapped to HTTP 501 in the new `errorsHandler` group middleware.
- Code generation delegates to `nanoid.CustomASCII`; `Validate` lowercases the caller-supplied code before cache lookup, making entry case-insensitive.
- New test file covers initialization, generation (alphabet/length), and validation (disabled, mixed case, invalid) paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core OTP changes are well-structured with test coverage, and the only finding is a minor dead-code concern in the error handler.

The switch to nanoid-based alphanumeric generation, case-insensitive validation, and the Enabled toggle are all implemented correctly and backed by new tests. The errorsHandler middleware contains two cases (ErrInvalidConfig, ErrInitFailed) that can only arise at startup and will never be reached at request time, but this does not affect any live request behavior.

**Files Needing Attention:** internal/sms-gateway/handlers/mobile.go — the two unreachable error cases in errorsHandler could be trimmed for clarity.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/otp/service.go | Replaces numeric crypto/rand generation with go-nanoid using a curated alnum alphabet; adds Enabled guard, shrinks TTL default, and makes Validate case-insensitive. |
| internal/sms-gateway/otp/config.go | Adds Enabled and Length fields; Validate() unconditionally enforces all constraints even when Enabled is false (flagged in previous review threads). |
| internal/sms-gateway/handlers/mobile.go | Adds errorsHandler middleware to the /mobile/v1 group for OTP error translation; two of the three matched error types (ErrInvalidConfig, ErrInitFailed) are startup-only and can never be reached at request time. |
| internal/config/config.go | Adds OTP.Enabled (default true) and OTP.Length (default 6) fields; Default() enables OTP by default, diverging from the example config intent flagged in previous threads. |
| internal/config/module.go | Wires Enabled and Length from the global config struct through to the OTP service config correctly. |
| internal/sms-gateway/otp/service_test.go | New test file covering service initialization, code generation (disabled, length, alphabet), and validation (disabled, valid code, mixed case, invalid code). |
| internal/sms-gateway/otp/errors.go | Adds ErrDisabled sentinel; straightforward addition. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant errorsHandler
    participant getUserCode
    participant auth.Service
    participant otp.Service
    participant Cache

    Client->>errorsHandler: GET /mobile/v1/user/code
    errorsHandler->>getUserCode: c.Next()
    getUserCode->>auth.Service: GenerateUserCode(ctx, userID)
    auth.Service->>otp.Service: Generate(ctx, userID)
    alt OTP disabled
        otp.Service-->>auth.Service: ErrDisabled
        auth.Service-->>getUserCode: wrapped ErrDisabled
        getUserCode-->>errorsHandler: wrapped ErrDisabled
        errorsHandler-->>Client: 501 Not Implemented
    else OTP enabled
        otp.Service->>Cache: "SetOrFail(code, userID, TTL=60s)"
        Cache-->>otp.Service: ok
        otp.Service-->>auth.Service: "Code{Code, ValidUntil}"
        auth.Service-->>getUserCode: "Code{Code, ValidUntil}"
        getUserCode-->>Client: "200 {code, valid_until}"
    end
```
</details>

<sub>Reviews (11): Last reviewed commit: ["\[otp\] decrease TTL and use alnum charact..."](https://github.com/android-sms-gateway/server/commit/5bebaa5d2214dcfc4d02558e2268679601d368b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47803624)</sub>

<!-- /greptile_comment -->