### PR TITLE
[handlers] use `client-go.SendOptions`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.21.0
-	github.com/android-sms-gateway/client-go v1.14.3
+	github.com/android-sms-gateway/client-go v1.14.4
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
-github.com/android-sms-gateway/client-go v1.14.3 h1:Yqg2tkztri8ruDU3LTO+TVQYdT3JyM/rVMaeeKgWKn8=
-github.com/android-sms-gateway/client-go v1.14.3/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.14.4 h1:kFGuiyChN1zgaKVOZ29AEXRufiWjzcpDS+IFhg6NaMo=
+github.com/android-sms-gateway/client-go v1.14.4/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -94,7 +94,7 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 		c.Context(),
 		userID,
 		req.DeviceID,
-		time.Duration(params.DeviceActiveWithin)*time.Hour,
+		time.Duration(lo.FromPtrOr(params.DeviceActiveWithin, 0))*time.Hour,
 	)
 	if err != nil {
 		h.Logger.Error(
@@ -144,7 +144,7 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 		c.Context(),
 		*device,
 		msg,
-		messages.EnqueueOptions{SkipPhoneValidation: params.SkipPhoneValidation},
+		messages.EnqueueOptions{SkipPhoneValidation: lo.FromPtrOr(params.SkipPhoneValidation, false)},
 	)
 	if err != nil {
 		h.Logger.Error(

--- a/internal/sms-gateway/handlers/messages/params.go
+++ b/internal/sms-gateway/handlers/messages/params.go
@@ -5,11 +5,12 @@ import (
 	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
 )
 
-type thirdPartyPostQueryParams struct {
-	SkipPhoneValidation bool `query:"skipPhoneValidation"`
-	DeviceActiveWithin  int  `query:"deviceActiveWithin"  validate:"omitempty,min=1"`
-}
-
+// thirdPartyPostQueryParams aliases smsgateway.SendOptions so that the query
+// parameter shape stays in sync with client-go. Note that any field with a
+// `query` struct tag added to SendOptions in a future client-go release will
+// automatically widen the surface of this endpoint; additions to SendOptions
+// must be reviewed deliberately here before merging.
+type thirdPartyPostQueryParams smsgateway.SendOptions
 type thirdPartyGetQueryParams smsgateway.ListMessagesOptions
 
 func (p *thirdPartyGetQueryParams) ToFilter() messages.SelectFilter {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates the hand-maintained `thirdPartyPostQueryParams` struct and replaces it with a type definition over `smsgateway.SendOptions`, so the POST `/3rdparty/v1/messages` query-parameter surface stays automatically in sync with the client library. It also bumps `client-go` to the stable `v1.14.4` tag, which includes the `omitzero` validation fix for `DeviceActiveWithin` addressed in previous review threads.

- `params.go`: `type thirdPartyPostQueryParams smsgateway.SendOptions` now drives the query-param shape; a comment explicitly flags that future `SendOptions` fields with `query` tags will automatically widen the endpoint surface.
- `3rdparty.go`: Both call sites updated to safely dereference the new pointer fields (`*bool`, `*uint`) via `lo.FromPtrOr`, preserving the same zero-value defaults as the old explicit fields.
- `go.mod`/`go.sum`: Bumped to `v1.14.4`, the stable tag carrying the `omitzero` fix.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. The change is a clean refactor that removes a hand-maintained struct in favour of the upstream type, and the dependency is now pinned to a stable, tagged release.
- The logic change is minimal and mechanical: two `lo.FromPtrOr` calls replace direct field accesses, the zero-value defaults are identical to the previous behaviour, and the `omitzero` validation fix shipped in `v1.14.4` resolves the `deviceActiveWithin=0` regression discussed in prior threads. No new code paths, no altered error handling, no schema changes.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/handlers/messages/params.go | Replaces the hand-rolled `thirdPartyPostQueryParams` struct with a type definition over `smsgateway.SendOptions`, keeping query-param parsing in sync with client-go; includes a clear coupling comment warning about future field additions. |
| internal/sms-gateway/handlers/messages/3rdparty.go | Updated two call sites to dereference pointer fields (`SkipPhoneValidation *bool`, `DeviceActiveWithin *uint`) from the new `SendOptions`-based params type using `lo.FromPtrOr`; logic is correct and zero-value defaults match the old behavior. |
| go.mod | Bumps `client-go` from `v1.14.3` to the stable `v1.14.4` tag, which carries the `omitzero` validation fix for `DeviceActiveWithin` discussed in the prior review thread. |
| go.sum | Checksum entries updated to reflect the `v1.14.4` hashes; no other changes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Fiber as Fiber Router
    participant Handler as ThirdPartyController.post
    participant QP as QueryParser (params)
    participant DS as DevicesService.GetAny
    participant MS as MessagesService.Enqueue

    Client->>Fiber: "POST /3rdparty/v1/messages?skipPhoneValidation=&deviceActiveWithin="
    Fiber->>Handler: post(userID, ctx)
    Handler->>QP: "QueryParserValidator(ctx, &params)"
    Note over QP: params is thirdPartyPostQueryParams<br/>(= smsgateway.SendOptions)<br/>Fields: SkipPhoneValidation *bool, DeviceActiveWithin *uint
    QP-->>Handler: params populated
    Handler->>DS: "GetAny(ctx, userID, deviceID,<br/>time.Duration(lo.FromPtrOr(params.DeviceActiveWithin, 0))*time.Hour)"
    DS-->>Handler: device or error
    Handler->>MS: "Enqueue(ctx, device, msg,<br/>EnqueueOptions{SkipPhoneValidation: lo.FromPtrOr(params.SkipPhoneValidation, false)})"
    MS-->>Handler: state or error
    Handler-->>Client: 202 Accepted + Location header
```
</details>

<sub>Reviews (9): Last reviewed commit: ["\[handlers\] use \`client-go.SendOptions\`"](https://github.com/android-sms-gateway/server/commit/1dec982697ad447407fae2e710e5cbb8771984fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48604527)</sub>

<!-- /greptile_comment -->