### PR TITLE
[api] handle not pending error on cancel with `409`

### DIFF
--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -318,11 +318,13 @@ func (h *ThirdPartyController) errorHandler(c *fiber.Ctx) error {
 		errors.Is(err, messages.ErrMultipleMessagesFound),
 		errors.Is(err, messages.ErrNoContent):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-
 	case errors.Is(err, messages.ErrMessageNotFound):
 		return fiber.NewError(fiber.StatusNotFound, err.Error())
-
 	case errors.Is(err, messages.ErrMessageAlreadyExists):
+		return fiber.NewError(fiber.StatusConflict, err.Error())
+	case errors.Is(err, messages.ErrQueueLimitExceeded):
+		return fiber.NewError(fiber.StatusServiceUnavailable, err.Error())
+	case errors.Is(err, messages.ErrMessageNotPending):
 		return fiber.NewError(fiber.StatusConflict, err.Error())
 
 	case errors.Is(err, devices.ErrNotFound):
@@ -333,9 +335,6 @@ func (h *ThirdPartyController) errorHandler(c *fiber.Ctx) error {
 		fallthrough
 	case errors.Is(err, devices.ErrMoreThanOne):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
-
-	case errors.Is(err, messages.ErrQueueLimitExceeded):
-		return fiber.NewError(fiber.StatusServiceUnavailable, err.Error())
 	}
 
 	h.Logger.Error("failed to handle request", zap.Error(err))


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR maps `ErrMessageNotPending` to HTTP `409 Conflict` in the third-party API error handler, so clients attempting to cancel a non-pending message now receive a clear conflict response instead of a generic 500. It also moves the `ErrQueueLimitExceeded` case earlier in the switch for consistency.

- `ErrMessageNotPending` is added to the `errorHandler` switch, returning `fiber.StatusConflict` (409).
- `ErrQueueLimitExceeded` is repositioned from after the `devices` error group to alongside the other message-domain errors — no behavior change.
- The Swagger annotation for `DELETE /3rdparty/v1/messages/{id}` is not updated to document the new 409 response code.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change correctly surfaces a pre-existing error condition as a proper HTTP status code.

The change adds a single, well-scoped error mapping and repositions one existing case. The logic is straightforward, existing error types are reused, and no new code paths are introduced.

**Files Needing Attention:** No files require special attention beyond the missing Swagger annotation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/handlers/messages/3rdparty.go | Adds `ErrMessageNotPending` → 409 mapping in the error handler and moves `ErrQueueLimitExceeded` earlier in the switch for better organization; Swagger annotation for DELETE is missing the new 409 response. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DELETE /3rdparty/v1/messages/:id] --> B[CancelMessage]
    B --> C{error?}
    C -- no --> D[200 OK - MessageState]
    C -- ErrMessageNotFound --> E[404 Not Found]
    C -- ErrMessageNotPending --> F[409 Conflict - NEW]
    C -- ErrQueueLimitExceeded --> G[503 Service Unavailable]
    C -- other --> H[500 Internal Server Error]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["\[api\] handle not pending error on cancel..."](https://github.com/android-sms-gateway/server/commit/9dcaa8b41f32e984d3f07860324b2f5c92c56887) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48937721)</sub>

<!-- /greptile_comment -->