### PR TITLE
[docs] fix swag annotations

### DIFF
--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -181,11 +181,11 @@ func (h *ThirdPartyController) post(userID string, c *fiber.Ctx) error {
 //	@Security		JWTAuth
 //	@Tags			User, Messages
 //	@Produce		json
-//	@Param			from			query		string							false	"Start date in RFC3339 format"															Format(date-time)
-//	@Param			to				query		string							false	"End date in RFC3339 format"															Format(date-time)
-//	@Param			state			query		string							false	"Filter messages by processing state"													Enum(Pending, Processed, Sent, Delivered, Failed)
-//	@Param			deviceId		query		string							false	"Filter by device ID"																	min(21)		max(21)
-//	@Param			limit			query		int								false	"Pagination limit"																		default(50)	min(1)	max(100)
+//	@Param			from			query		string							false	"Start date in RFC3339 format"	Format(date-time)
+//	@Param			to				query		string							false	"End date in RFC3339 format"	Format(date-time)
+//	@Param			state			query		smsgateway.ProcessingState		false	"Filter messages by processing state"
+//	@Param			deviceId		query		string							false	"Filter by device ID"																	minLength(21)	maxLength(21)
+//	@Param			limit			query		int								false	"Pagination limit"																		default(50)		minimum(1)	maximum(100)
 //	@Param			offset			query		int								false	"Pagination offset"																		default(0)
 //	@Param			includeContent	query		bool							false	"Include textMessage/dataMessage content for each message. Default is false"			default(false)
 //	@Param			sort			query		string							false	"Sort order per JSON:API spec. Use created_at (ascending) or -created_at (descending)"	Enums(created_at, -created_at)	default(-created_at)

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -642,18 +642,31 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "enum": [
+                            "Pending",
+                            "Cancelling",
+                            "Cancelled",
+                            "Processed",
+                            "Sent",
+                            "Delivered",
+                            "Failed"
+                        ],
                         "type": "string",
                         "description": "Filter messages by processing state",
                         "name": "state",
                         "in": "query"
                     },
                     {
+                        "maxLength": 21,
+                        "minLength": 21,
                         "type": "string",
                         "description": "Filter by device ID",
                         "name": "deviceId",
                         "in": "query"
                     },
                     {
+                        "maximum": 100,
+                        "minimum": 1,
                         "type": "integer",
                         "default": 50,
                         "description": "Pagination limit",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects Swagger annotations and regenerates the OpenAPI specification.
- Documents the complete processing-state enum.
- Adds device ID length and pagination limit constraints.
- Preserves separate `limit` and `offset` query parameters.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/handlers/messages/3rdparty.go | Corrects Swagger parameter types and constraint syntax; the previously concatenated parameter annotation is now properly separated. |
| internal/sms-gateway/openapi/docs.go | Regenerates the OpenAPI document with the expected state enum, device ID length constraints, and pagination bounds. |

</details>

<sub>Reviews (4): Last reviewed commit: ["\[docs\] fix swag annotations"](https://github.com/android-sms-gateway/server/commit/96663e1ed3b99ccdc1f051d5c95b769b2e050dde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51431802)</sub>

<!-- /greptile_comment -->