### PR TITLE
[messages] register pending state in history

### DIFF
--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -69,6 +69,12 @@ func newMessageModel(
 		Recipients: lo.Map(phoneNumbers, func(item string, _ int) messageRecipientModel {
 			return newMessageRecipient(item, ProcessingStatePending, nil)
 		}),
+		States: []messageStateModel{
+			{
+				State:     ProcessingStatePending,
+				UpdatedAt: time.Now(),
+			},
+		},
 		Priority:           priority,
 		SimNumber:          simNumber,
 		ValidUntil:         validUntil,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the initial pending state to each newly created message’s persisted state history.
- Initializes `States` alongside the existing pending top-level and recipient states.
- Records the initial state transition timestamp when constructing the message.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new pending history entry is persisted through the existing association, duplicate state reports are safely ignored by the unique state constraint, and the Android consumer supports pending entries in its state model.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/modules/messages/models.go | Initializes new messages with a pending history entry; existing persistence uniqueness and client contracts are compatible with the change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["\[messages\] register pending state in his..."](https://github.com/android-sms-gateway/server/commit/1d639c79555dd024eedc1081149cf2451658d93c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53538375)</sub>

<!-- /greptile_comment -->