### PR TITLE
[messages] require phone numbers uniqness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/samber/lo v1.53.0
+	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/swag v1.16.6
 	go.uber.org/fx v1.24.0
 	go.uber.org/zap v1.28.0
@@ -56,6 +57,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
@@ -99,6 +101,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pressly/goose/v3 v3.27.3 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect

--- a/internal/sms-gateway/handlers/messages/3rdparty.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty.go
@@ -72,7 +72,7 @@ func NewThirdPartyController(params thirdPartyControllerParams) *ThirdPartyContr
 //	@Failure		400					{object}	smsgateway.ErrorResponse		"Invalid request"
 //	@Failure		401					{object}	smsgateway.ErrorResponse		"Unauthorized"
 //	@Failure		403					{object}	smsgateway.ErrorResponse		"Forbidden"
-//	@Failure		409					{object}	smsgateway.ErrorResponse		"Message with such ID already exists"
+//	@Failure		409					{object}	smsgateway.ErrorResponse		"Message with the same ID already exists"
 //	@Failure		500					{object}	smsgateway.ErrorResponse		"Internal server error"
 //	@Failure		503					{object}	smsgateway.ErrorResponse		"Queue limits exceeded; ensure device is online"
 //	@Header			202					{string}	Location						"Get message state URL"
@@ -314,14 +314,16 @@ func (h *ThirdPartyController) errorHandler(c *fiber.Ctx) error {
 
 	var msgValidationError messages.ValidationError
 	switch {
-	case errors.As(err, &msgValidationError),
-		errors.Is(err, messages.ErrMultipleMessagesFound),
-		errors.Is(err, messages.ErrNoContent):
+	case errors.As(err, &msgValidationError):
+		return fiber.NewError(fiber.StatusBadRequest, msgValidationError.Error())
+	case errors.Is(err, messages.ErrMultipleMessagesFound):
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	case errors.Is(err, messages.ErrNoContent):
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	case errors.Is(err, messages.ErrMessageNotFound):
 		return fiber.NewError(fiber.StatusNotFound, err.Error())
 	case errors.Is(err, messages.ErrMessageAlreadyExists):
-		return fiber.NewError(fiber.StatusConflict, err.Error())
+		return fiber.NewError(fiber.StatusConflict, messages.ErrMessageAlreadyExists.Error())
 	case errors.Is(err, messages.ErrQueueLimitExceeded):
 		return fiber.NewError(fiber.StatusServiceUnavailable, err.Error())
 	case errors.Is(err, messages.ErrMessageNotPending):

--- a/internal/sms-gateway/handlers/messages/3rdparty_test.go
+++ b/internal/sms-gateway/handlers/messages/3rdparty_test.go
@@ -1,0 +1,149 @@
+//nolint:testpackage // errorHandler is unexported; in-package test required.
+package messages
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/android-sms-gateway/server/internal/sms-gateway/handlers/base"
+	"github.com/android-sms-gateway/server/internal/sms-gateway/modules/devices"
+	messages "github.com/android-sms-gateway/server/internal/sms-gateway/modules/messages"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newTestThirdPartyController() *ThirdPartyController {
+	return &ThirdPartyController{
+		Handler: base.Handler{
+			Logger: zap.NewNop(),
+		},
+	}
+}
+
+func TestThirdPartyControllerErrorHandler(t *testing.T) {
+	const enqueueWrap = "failed to enqueue message: %w"
+
+	tests := []struct {
+		name       string
+		handlerErr error
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "wrapped validation error emits its own text (no wrap prefix)",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ValidationError("phone numbers must be unique")),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":"phone numbers must be unique"}`,
+		},
+		{
+			name:       "wrapped duplicate ID emits sentinel text (no wrap prefix)",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ErrMessageAlreadyExists),
+			wantStatus: fiber.StatusConflict,
+			wantBody:   `{"message":"message with the same ID already exists"}`,
+		},
+		{
+			name:       "wrapped multiple messages found keeps err.Error() text (unchanged)",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ErrMultipleMessagesFound),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":"failed to enqueue message: multiple messages found"}`,
+		},
+		{
+			name:       "wrapped no content keeps err.Error() text (unchanged)",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ErrNoContent),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":"failed to enqueue message: no text or data content"}`,
+		},
+		{
+			name:       "bare validation error keeps its own text",
+			handlerErr: messages.ValidationError("invalid phone number"),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":"invalid phone number"}`,
+		},
+		{
+			name:       "wrapped validation error variation",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ValidationError("not mobile phone number")),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":"not mobile phone number"}`,
+		},
+		{
+			name:       "zero-value validation error emits its own empty text (no wrap prefix)",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ValidationError("")),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":""}`,
+		},
+		{
+			name:       "not found keeps 404",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ErrMessageNotFound),
+			wantStatus: fiber.StatusNotFound,
+			wantBody:   `{"message":"failed to enqueue message: message not found"}`,
+		},
+		{
+			name:       "queue limit keeps 503",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ErrQueueLimitExceeded),
+			wantStatus: fiber.StatusServiceUnavailable,
+			wantBody:   `{"message":"failed to enqueue message: queue limits exceeded"}`,
+		},
+		{
+			name:       "not pending keeps 409",
+			handlerErr: fmt.Errorf(enqueueWrap, messages.ErrMessageNotPending),
+			wantStatus: fiber.StatusConflict,
+			wantBody:   `{"message":"failed to enqueue message: message is not pending"}`,
+		},
+		{
+			name:       "device not found keeps 400",
+			handlerErr: fmt.Errorf("failed to select device: %w", devices.ErrNotFound),
+			wantStatus: fiber.StatusBadRequest,
+			wantBody:   `{"message":"failed to select device: record not found"}`,
+		},
+		{
+			name:       "unknown error keeps 500",
+			handlerErr: errors.New("boom"),
+			wantStatus: fiber.StatusInternalServerError,
+			wantBody:   `{"message":"failed to handle request"}`,
+		},
+		{
+			name:       "fiber error passes through unchanged",
+			handlerErr: fmt.Errorf("wrapped: %w", fiber.NewError(fiber.StatusTeapot, "teapot")),
+			wantStatus: fiber.StatusTeapot,
+			wantBody:   `{"message":"teapot"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestThirdPartyController()
+
+			app := fiber.New(fiber.Config{
+				// Mirrors go-infra-fx/http errorHandler ({"message": err.Error()}).
+				ErrorHandler: func(c *fiber.Ctx, err error) error {
+					code := fiber.StatusInternalServerError
+					var fiberErr *fiber.Error
+					if errors.As(err, &fiberErr) {
+						code = fiberErr.Code
+					}
+					return c.Status(code).JSON(&fiber.Map{"message": err.Error()})
+				},
+			})
+			app.Use(h.errorHandler)
+			app.Post("/enqueue", func(_ *fiber.Ctx) error {
+				return tt.handlerErr
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/enqueue", nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBody, string(body))
+		})
+	}
+}

--- a/internal/sms-gateway/modules/messages/errors.go
+++ b/internal/sms-gateway/modules/messages/errors.go
@@ -3,7 +3,7 @@ package messages
 import "errors"
 
 var (
-	ErrMessageAlreadyExists  = errors.New("duplicate id")
+	ErrMessageAlreadyExists  = errors.New("message with the same ID already exists")
 	ErrMessageNotFound       = errors.New("message not found")
 	ErrMultipleMessagesFound = errors.New("multiple messages found")
 	ErrNoContent             = errors.New("no text or data content")

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -310,6 +310,14 @@ func (s *Service) prepareMessage(
 		message.PhoneNumbers[i] = phone
 	}
 
+	seen := make(map[string]struct{}, len(message.PhoneNumbers))
+	for _, phone := range message.PhoneNumbers {
+		if _, ok := seen[phone]; ok {
+			return nil, ValidationError("phone numbers must be unique")
+		}
+		seen[phone] = struct{}{}
+	}
+
 	validUntil := message.ValidUntil
 	if message.TTL != nil && *message.TTL > 0 {
 		//nolint:gosec // not a problem

--- a/internal/sms-gateway/modules/push/fcm/client.go
+++ b/internal/sms-gateway/modules/push/fcm/client.go
@@ -69,7 +69,7 @@ func (c *Client) Send(ctx context.Context, messages []client.Message) ([]error, 
 			Android: &messaging.AndroidConfig{
 				Priority: "high",
 			},
-			Token: message.Token,
+			Token: message.Token, //nolint:staticcheck //migration to Fid is planned
 		})
 		if err != nil {
 			errs[i] = fmt.Errorf("failed to send message: %w", err)

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -819,7 +819,7 @@ const docTemplate = `{
                         }
                     },
                     "409": {
-                        "description": "Message with such ID already exists",
+                        "description": "Message with the same ID already exists",
                         "schema": {
                             "$ref": "#/definitions/smsgateway.ErrorResponse"
                         }

--- a/test/e2e/messages_test.go
+++ b/test/e2e/messages_test.go
@@ -348,3 +348,124 @@ func TestMessages_GetMessages(t *testing.T) {
 		})
 	}
 }
+
+func TestMessages_Post(t *testing.T) {
+	credentials := mobileDeviceRegister(t, publicMobileClient)
+	authorizedClient := publicUserClient.Clone().SetBasicAuth(credentials.Login, credentials.Password)
+
+	cases := []struct {
+		name               string
+		req                map[string]any
+		expectedStatusCode int
+		expectedMessage    string
+	}{
+		{
+			name: "duplicate phone numbers are rejected",
+			req: map[string]any{
+				"message": "test",
+				"phoneNumbers": []string{
+					"+79999999999",
+					"+79999999999",
+				},
+			},
+			expectedStatusCode: 400,
+			expectedMessage:    "phone numbers must be unique",
+		},
+		{
+			name: "distinct phone numbers are accepted",
+			req: map[string]any{
+				"message": "test",
+				"phoneNumbers": []string{
+					"+79999999999",
+					"+79990001234",
+				},
+			},
+			expectedStatusCode: 202,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := authorizedClient.R().
+				SetHeader("Content-Type", "application/json").
+				SetBody(c.req).
+				Post("messages")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode() != c.expectedStatusCode {
+				t.Fatal(res.StatusCode(), res.String())
+			}
+
+			if c.expectedMessage != "" {
+				var resp errorResponse
+				if err := json.Unmarshal(res.Body(), &resp); err != nil {
+					t.Fatal(err)
+				}
+
+				if resp.Message != c.expectedMessage {
+					t.Errorf("expected message %q, got %q", c.expectedMessage, resp.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestMessages_PostDuplicateMessageID(t *testing.T) {
+	credentials := mobileDeviceRegister(t, publicMobileClient)
+	authorizedClient := publicUserClient.Clone().SetBasicAuth(credentials.Login, credentials.Password)
+
+	// The message ID uniqueness scope is per device (unq_messages_id_device),
+	// so pin the device to guarantee the ExtID collision.
+	base := map[string]any{
+		"id":           "e2e-duplicate-message-id",
+		"message":      "test",
+		"deviceId":     credentials.ID,
+		"phoneNumbers": []string{"+79999999999"},
+	}
+
+	t.Run("first message with the ID is accepted", func(t *testing.T) {
+		res, err := authorizedClient.R().
+			SetHeader("Content-Type", "application/json").
+			SetBody(base).
+			Post("messages")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.StatusCode() != 202 {
+			t.Fatal(res.StatusCode(), res.String())
+		}
+	})
+
+	t.Run("duplicate message ID is rejected", func(t *testing.T) {
+		req := map[string]any{
+			"id":           base["id"],
+			"message":      "test",
+			"deviceId":     credentials.ID,
+			"phoneNumbers": []string{"+79990001234"},
+		}
+
+		res, err := authorizedClient.R().
+			SetHeader("Content-Type", "application/json").
+			SetBody(req).
+			Post("messages")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.StatusCode() != 409 {
+			t.Fatal(res.StatusCode(), res.String())
+		}
+
+		var resp errorResponse
+		if err := json.Unmarshal(res.Body(), &resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Message != "message with the same ID already exists" {
+			t.Errorf("expected message %q, got %q", "Message with the same ID already exists", resp.Message)
+		}
+	})
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enforces recipient phone-number uniqueness after normal validation and improves client-facing duplicate-ID and validation errors.
- Rejects repeated normalized phone numbers during message preparation.
- Returns concise validation and duplicate-ID responses through the third-party API.
- Adds handler and end-to-end coverage for uniqueness and duplicate message IDs.
- Updates generated OpenAPI wording and suppresses a planned FCM token deprecation warning.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/sms-gateway/modules/messages/service.go | Normalizes recipients and rejects duplicate resulting phone-number strings before preparing the message. |
| internal/sms-gateway/handlers/messages/3rdparty.go | Maps wrapped validation and duplicate-ID errors to concise client-facing HTTP responses. |
| internal/sms-gateway/handlers/messages/3rdparty_test.go | Adds focused coverage for error status and response-message behavior. |
| test/e2e/messages_test.go | Adds end-to-end coverage for duplicate recipients, distinct recipients, and duplicate message IDs. |
| go.mod | Promotes testify to a direct test dependency and records its indirect dependencies. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Message request] --> B[Validate and normalize phone numbers]
    B --> C{Normalized number already seen?}
    C -- Yes --> D[Return validation error]
    C -- No --> E[Record number]
    E --> F{More recipients?}
    F -- Yes --> B
    F -- No --> G[Prepare and enqueue message]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["\[lint\] ignore FCM Fid migration"](https://github.com/android-sms-gateway/server/commit/65f863f89cf235f11de1e686b396025962befc5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53870853)</sub>

<!-- /greptile_comment -->