### PR TITLE
[messages] optimize database indexes

### DIFF
--- a/internal/sms-gateway/models/migrations/mysql/20260817000000_optimize_messages_indexes.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260817000000_optimize_messages_indexes.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_created_at` ON `messages` (`created_at`);
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_device_created_at` ON `messages` (`device_id`, `created_at`);
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX `idx_messages_is_hashed` ON `messages`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_unhashed` ON `messages` (`is_hashed`, `is_encrypted`, `state`);
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX `idx_messages_unhashed` ON `messages`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_is_hashed` USING HASH ON `messages` (`is_hashed`);
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX `idx_messages_device_created_at` ON `messages`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+DROP INDEX `idx_messages_created_at` ON `messages`;
+-- +goose StatementEnd

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -32,19 +32,19 @@ type messageModel struct {
 	models.SoftDeletableModel
 
 	ID                 uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
-	DeviceID           string          `gorm:"not null;type:char(21);uniqueIndex:unq_messages_id_device,priority:2;index:idx_messages_device_state"`
+	DeviceID           string          `gorm:"not null;type:char(21);uniqueIndex:unq_messages_id_device,priority:2;index:idx_messages_device_state;index:idx_messages_device_created_at,priority:1"`
 	ExtID              string          `gorm:"not null;type:varchar(36);uniqueIndex:unq_messages_id_device,priority:1"`
 	Type               MessageType     `gorm:"not null;type:enum('Text','Data');default:Text"`
 	Content            string          `gorm:"not null;type:text"`
-	State              ProcessingState `gorm:"not null;type:enum('Pending','Cancelling','Cancelled','Processed','Sent','Delivered','Failed');default:Pending;index:idx_messages_device_state"`
+	State              ProcessingState `gorm:"not null;type:enum('Pending','Cancelling','Cancelled','Processed','Sent','Delivered','Failed');default:Pending;index:idx_messages_device_state;index:idx_messages_unhashed,priority:3"`
 	ValidUntil         *time.Time      `gorm:"type:datetime"`
 	ScheduleAt         *time.Time      `gorm:"type:datetime"`
 	SimNumber          *uint8          `gorm:"type:tinyint(1) unsigned"`
 	WithDeliveryReport bool            `gorm:"not null;type:tinyint(1) unsigned"`
 	Priority           int8            `gorm:"not null;type:tinyint;default:0"`
 
-	IsHashed    bool `gorm:"not null;type:tinyint(1) unsigned;default:0"`
-	IsEncrypted bool `gorm:"not null;type:tinyint(1) unsigned;default:0"`
+	IsHashed    bool `gorm:"not null;type:tinyint(1) unsigned;default:0;index:idx_messages_unhashed,priority:1"`
+	IsEncrypted bool `gorm:"not null;type:tinyint(1) unsigned;default:0;index:idx_messages_unhashed,priority:2"`
 
 	Device     devices.DeviceModel     `gorm:"foreignKey:DeviceID;constraint:OnDelete:CASCADE"`
 	Recipients []messageRecipientModel `gorm:"foreignKey:MessageID;constraint:OnDelete:CASCADE"`


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR optimizes indexes used by message retrieval, cleanup, and hashing workflows.
- Adds indexes on `created_at` and `(device_id, created_at)`.
- Replaces the single-column hashing index with `(is_hashed, is_encrypted, state)`.
- Aligns the corresponding composite indexes with GORM model metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the available follow-up review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/sms-gateway/models/migrations/mysql/20260817000000_optimize_messages_indexes.sql | Adds and rolls back the optimized message indexes; no eligible follow-up defect was established. |
| internal/sms-gateway/modules/messages/models.go | Updates GORM tags to declare the new device/creation-time and unhashed-message composite indexes. |

</details>

<sub>Reviews (5): Last reviewed commit: ["\[messages\] optimize database indexes"](https://github.com/android-sms-gateway/server/commit/53ec71234d0e00f00867a7d9fa300898f196bd34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53878953)</sub>

<!-- /greptile_comment -->