### PR TITLE
[deploy] fix SSE monitoring window

### DIFF
--- a/deployments/prometheus/server.rules.yml
+++ b/deployments/prometheus/server.rules.yml
@@ -372,14 +372,14 @@ groups:
           dashboard: "http://grafana/d/sse-metrics"
 
       - alert: SSEClientConnectionLoss
-        expr: max_over_time(sms_sse_active_connections[10m]) > 0 and sms_sse_active_connections == 0
+        expr: max_over_time(sms_sse_active_connections[1h]) > 0 and sms_sse_active_connections == 0
         for: 5m
         labels:
           severity: warning
           service: sse
         annotations:
           summary: "SSE clients disconnected"
-          description: "SSE clients were connected within the last 10 minutes but there are no active connections now. Clients may have lost real-time updates."
+          description: "SSE clients were connected within the last hour but there are no active connections now. Clients may have lost real-time updates."
           runbook: "Check SSE connections and gateway health; review sse module logs"
           dashboard: "http://grafana/d/sse-metrics"
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends the SSE client connection-loss alert’s historical monitoring window from 10 minutes to one hour and updates its description accordingly.
- Uses a one-hour `max_over_time` range when detecting a drop to zero active SSE connections.
- Keeps the existing five-minute alerting threshold and operational annotations unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the alert expression and its explanatory text consistently implement the intended monitoring-window change.

The changed rule extends only the historical connection lookback; its five-minute firing duration, current-connection check, labels, and operational guidance remain intact, with no concrete blocking failure established.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| deployments/prometheus/server.rules.yml | The alert expression and description consistently adopt the intended one-hour SSE monitoring window without introducing an established actionable defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["\[deploy\] fix SSE monitoring window"](https://github.com/android-sms-gateway/server/commit/b20f29ac1cc7f35b5fcd1e57a3a873b69923fca5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54216985)</sub>

<!-- /greptile_comment -->