### PR TITLE
[messages] optimize list query by denormaliztion

### DIFF
--- a/internal/sms-gateway/models/migrations/mysql/20260826120000_add_messages_user_id.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260826120000_add_messages_user_id.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `messages`
+ADD COLUMN `user_id` varchar(32) NULL
+AFTER `device_id`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+UPDATE `messages` `m`
+    JOIN `devices` `d` ON `m`.`device_id` = `d`.`id`
+SET `m`.`user_id` = `d`.`user_id`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `messages`
+MODIFY `user_id` varchar(32) NOT NULL;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_user_created_at` ON `messages` (`user_id`, `created_at`, `id`);
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX `idx_messages_user_created_at` ON `messages`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+ALTER TABLE `messages` DROP COLUMN `user_id`;
+-- +goose StatementEnd

--- a/internal/sms-gateway/modules/devices/repository.go
+++ b/internal/sms-gateway/modules/devices/repository.go
@@ -90,6 +90,9 @@ func (r *Repository) Insert(ctx context.Context, device DeviceInput) (*Device, e
 }
 
 func (r *Repository) Update(ctx context.Context, id string, device DeviceUpdate) error {
+	// NOTE: `user_id` is intentionally not updatable. messages.user_id is
+	// denormalized from devices.user_id (see 20260826120000_add_messages_user_id);
+	// changing a device's owner requires backfilling messages.user_id too.
 	updates := map[string]any{}
 
 	if device.PushToken != nil {

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -32,6 +32,7 @@ type messageModel struct {
 	models.SoftDeletableModel
 
 	ID                 uint64          `gorm:"primaryKey;type:BIGINT UNSIGNED;autoIncrement"`
+	UserID             string          `gorm:"not null;type:varchar(32);index:idx_messages_user_created_at,priority:1"`
 	DeviceID           string          `gorm:"not null;type:char(21);uniqueIndex:unq_messages_id_device,priority:2;index:idx_messages_device_state;index:idx_messages_device_created_at,priority:1"`
 	ExtID              string          `gorm:"not null;type:varchar(36);uniqueIndex:unq_messages_id_device,priority:1"`
 	Type               MessageType     `gorm:"not null;type:enum('Text','Data');default:Text"`
@@ -52,6 +53,7 @@ type messageModel struct {
 }
 
 func newMessageModel(
+	userID string,
 	extID string,
 	deviceID string,
 	phoneNumbers []string,
@@ -65,6 +67,7 @@ func newMessageModel(
 	//nolint:exhaustruct // partial constructor
 	return &messageModel{
 		ExtID:    extID,
+		UserID:   userID,
 		DeviceID: deviceID,
 		Recipients: lo.Map(phoneNumbers, func(item string, _ int) messageRecipientModel {
 			return newMessageRecipient(item, ProcessingStatePending, nil)

--- a/internal/sms-gateway/modules/messages/repository.go
+++ b/internal/sms-gateway/modules/messages/repository.go
@@ -41,9 +41,7 @@ func (r *Repository) list(filter SelectFilter, options SelectOptions) ([]message
 
 	// Apply user filter
 	if filter.UserID != "" {
-		query = query.
-			Joins("JOIN devices ON messages.device_id = devices.id").
-			Where("devices.user_id = ?", filter.UserID)
+		query = query.Where("messages.user_id = ?", filter.UserID)
 	}
 
 	// Apply state filter

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -331,6 +331,7 @@ func (s *Service) prepareMessage(
 	}
 
 	msg := newMessageModel(
+		device.UserID,
 		message.ID,
 		device.ID,
 		message.PhoneNumbers,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR denormalizes device ownership onto message rows to eliminate the devices-table join from user-scoped message-list queries.

- Adds and backfills a required `messages.user_id` column plus a composite list index.
- Populates ownership when constructing new messages.
- Filters message lists directly by the denormalized owner.
- Documents that device ownership must remain immutable unless message ownership is also backfilled.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the migration, write path, and optimized read path consistently maintaining message ownership.

Existing rows are backfilled under the enforced message-to-device relationship, and every current production enqueue path stores the selected device's user identifier before list queries begin filtering on it.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/sms-gateway/models/migrations/mysql/20260826120000_add_messages_user_id.sql | Adds the ownership column through a nullable backfill phase, makes it required, and creates the optimized composite index. |
| internal/sms-gateway/modules/messages/models.go | Extends persisted messages and their constructor with the denormalized user identifier. |
| internal/sms-gateway/modules/messages/repository.go | Replaces the ownership join with a direct filter on the backfilled message column. |
| internal/sms-gateway/modules/messages/service.go | Supplies the selected persisted device's owner when constructing every production message. |
| internal/sms-gateway/modules/devices/repository.go | Documents the ownership immutability needed to keep denormalized message ownership consistent. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Enqueue request] --> Device[Selected persisted device]
  Device --> Prepare[Prepare message with device.user_id]
  Prepare --> Messages[(messages)]
  Migration[Schema migration] --> Backfill[Backfill user_id from devices]
  Backfill --> Messages
  List[User-scoped list request] --> Filter[Filter messages.user_id]
  Filter --> Messages
```
</details>

<sub>Reviews (1): Last reviewed commit: ["\[messages\] optimize list query by denorm..."](https://github.com/android-sms-gateway/server/commit/fed6a5e9762756a198588eb3f885649cac67eb8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56919599)</sub>

**Context used:**

- Knowledge Base — [SMS message delivery lifecycle](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/android-sms-gateway/server/-/docs/message-delivery-lifecycle.md)
- Knowledge Base — [Database schema and persistence](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/android-sms-gateway/server/-/docs/database-schema-and-persistence.md)

<!-- /greptile_comment -->