### PR TITLE
[messages] optimize index storage

### DIFF
--- a/internal/sms-gateway/models/migrations/mysql/20260826130000_trim_messages_user_index.sql
+++ b/internal/sms-gateway/models/migrations/mysql/20260826130000_trim_messages_user_index.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX `idx_messages_user_created_at` ON `messages`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_user_created_at` ON `messages` (`user_id`, `created_at`);
+-- +goose StatementEnd
+---
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX `idx_messages_user_created_at` ON `messages`;
+-- +goose StatementEnd
+-- +goose StatementBegin
+CREATE INDEX `idx_messages_user_created_at` ON `messages` (`user_id`, `created_at`, `id`);
+-- +goose StatementEnd

--- a/internal/sms-gateway/modules/messages/repository.go
+++ b/internal/sms-gateway/modules/messages/repository.go
@@ -198,8 +198,7 @@ func (r *Repository) HashProcessed(ctx context.Context, ids []uint64) (int64, er
 
 func (r *Repository) CancelMessage(userID string, id string) error {
 	res := r.db.Model((*messageModel)(nil)).
-		Where("ext_id = ? AND state = ?", id, ProcessingStatePending).
-		Where("device_id IN (?)", r.db.Table("devices").Select("id").Where("user_id = ?", userID)).
+		Where("ext_id = ? AND state = ? AND user_id = ?", id, ProcessingStatePending, userID).
 		Update("state", ProcessingStateCancelling)
 	if res.Error != nil {
 		return fmt.Errorf("failed to cancel message: %w", res.Error)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces explicit storage for the message-history index and updates cancellation to use the newly denormalized message owner.
- Recreates `idx_messages_user_created_at` without explicitly storing the primary-key column.
- Scopes pending-message cancellation directly by `messages.user_id` instead of a device-ownership subquery.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security issues identified.

The trimmed InnoDB index retains the primary-key suffix implicitly, and all current creation, migration, and ownership-update paths keep the new message-level cancellation predicate equivalent to the previous device-owner predicate.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/sms-gateway/models/migrations/mysql/20260826130000_trim_messages_user_index.sql | Recreates the user/history index without an explicitly redundant InnoDB primary-key suffix and restores the prior definition on rollback. |
| internal/sms-gateway/modules/messages/repository.go | Aligns the cancellation update predicate with the message-level user ownership already enforced by the service and repository reads. |

</details>

<sub>Reviews (1): Last reviewed commit: ["\[messages\] optimize index storage"](https://github.com/android-sms-gateway/server/commit/b0809227e96ccc9b6e967689cd0e000747227bdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57769926)</sub>

**Context used:**

- Knowledge Base — [SMS message delivery lifecycle](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/android-sms-gateway/server/-/docs/message-delivery-lifecycle.md)
- Knowledge Base — [Database schema and persistence](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/android-sms-gateway/server/-/docs/database-schema-and-persistence.md)

<!-- /greptile_comment -->