### PR TITLE
[messages] expose `createdAt` field in status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	firebase.google.com/go/v4 v4.21.0
-	github.com/android-sms-gateway/client-go v1.14.5
+	github.com/android-sms-gateway/client-go v1.15.1-0.20260831040827-45278c69c3e9
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/capcom6/go-helpers v0.4.0
 	github.com/capcom6/go-infra-fx v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID
 github.com/MicahParks/keyfunc v1.9.0/go.mod h1:IdnCilugA0O/99dW+/MkvlyrsX8+L8+x95xuVNtM5jw=
 github.com/android-sms-gateway/client-go v1.14.5 h1:CtyXAHPdyDtCFTzeVPt5EUfnWhQ2RsIWbCUk52tbGjw=
 github.com/android-sms-gateway/client-go v1.14.5/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
+github.com/android-sms-gateway/client-go v1.15.1-0.20260831040827-45278c69c3e9 h1:/REm4VYPWTPAjB06JuM+iCSmcLcvepURbwqsz8KCIaI=
+github.com/android-sms-gateway/client-go v1.15.1-0.20260831040827-45278c69c3e9/go.mod h1:DQsReciU1xcaVW3T5Z2bqslNdsAwCFCtghawmA6g6L4=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/ansrivas/fiberprometheus/v2 v2.17.0 h1:p0gqs5LsSCWGoSFF44fCJkyU+XcE6TLRqEMu80b2iCo=

--- a/internal/sms-gateway/handlers/converters/messages.go
+++ b/internal/sms-gateway/handlers/converters/messages.go
@@ -30,6 +30,7 @@ func MessageToMobileDTO(m messages.Message) smsgateway.MobileMessage {
 			Message:     message,
 			TextMessage: textMessage,
 			DataMessage: dataMessage,
+			MmsMessage:  nil,
 
 			SimNumber:          m.SimNumber,
 			WithDeliveryReport: m.WithDeliveryReport,
@@ -54,9 +55,11 @@ func MessageStateToDTO(state messages.MessageState) smsgateway.MessageState {
 		IsEncrypted: state.IsEncrypted,
 		Recipients:  state.Recipients,
 		States:      state.States,
+		CreatedAt:   state.CreatedAt,
 
 		TextMessage:   state.TextContent,
 		DataMessage:   state.DataContent,
+		MmsMessage:    nil,
 		HashedMessage: state.HashedContent,
 	}
 }

--- a/internal/sms-gateway/handlers/converters/messages_test.go
+++ b/internal/sms-gateway/handlers/converters/messages_test.go
@@ -92,3 +92,117 @@ func TestMessageToDTO(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageStateToDTO(t *testing.T) {
+	// Set up a fixed time for testing
+	now := time.Date(2023, 6, 15, 12, 30, 45, 123456789, time.UTC)
+
+	// Define test cases
+	tests := []struct {
+		name     string
+		input    messages.MessageState
+		expected smsgateway.MessageState
+	}{
+		{
+			name: "Full state with all fields",
+			input: messages.MessageState{
+				MessageStateInput: messages.MessageStateInput{
+					ID:    "msg-123",
+					State: messages.ProcessingStateDelivered,
+					Recipients: []smsgateway.RecipientState{
+						{PhoneNumber: "+1234567890", State: smsgateway.ProcessingStateDelivered},
+						{
+							PhoneNumber: "+9876543210",
+							State:       smsgateway.ProcessingStateFailed,
+							Error:       lo.ToPtr("timeout"),
+						},
+					},
+					States: map[string]time.Time{
+						string(messages.ProcessingStatePending):   now.Add(-time.Hour),
+						string(messages.ProcessingStateDelivered): now,
+					},
+				},
+				MessageStateContent: messages.MessageStateContent{
+					MessageContent: messages.MessageContent{
+						TextContent: &messages.TextMessageContent{Text: "Test message content"},
+					},
+				},
+				DeviceID:    "device-1",
+				IsHashed:    false,
+				IsEncrypted: true,
+				CreatedAt:   now,
+			},
+			expected: smsgateway.MessageState{
+				ID:          "msg-123",
+				DeviceID:    "device-1",
+				State:       smsgateway.ProcessingStateDelivered,
+				IsHashed:    false,
+				IsEncrypted: true,
+				Recipients: []smsgateway.RecipientState{
+					{PhoneNumber: "+1234567890", State: smsgateway.ProcessingStateDelivered},
+					{PhoneNumber: "+9876543210", State: smsgateway.ProcessingStateFailed, Error: lo.ToPtr("timeout")},
+				},
+				States: map[string]time.Time{
+					string(messages.ProcessingStatePending):   now.Add(-time.Hour),
+					string(messages.ProcessingStateDelivered): now,
+				},
+				TextMessage: &smsgateway.TextMessage{Text: "Test message content"},
+				CreatedAt:   now,
+			},
+		},
+		{
+			name: "Data and hashed content",
+			input: messages.MessageState{
+				MessageStateInput: messages.MessageStateInput{
+					ID:    "msg-456",
+					State: messages.ProcessingStateSent,
+					Recipients: []smsgateway.RecipientState{
+						{PhoneNumber: "+1122334455", State: smsgateway.ProcessingStateSent},
+					},
+					States: map[string]time.Time{string(messages.ProcessingStateSent): now},
+				},
+				MessageStateContent: messages.MessageStateContent{
+					MessageContent: messages.MessageContent{
+						DataContent: &messages.DataMessageContent{Data: "SGVsbG8gV29ybGQh", Port: uint16(53739)},
+					},
+					HashedContent: &messages.HashedMessageContent{Hash: "1d4b6e3b1b6e3b1b6e3b1b6e3b1b6e3b1b6e3b1b"},
+				},
+				DeviceID:  "device-2",
+				IsHashed:  true,
+				CreatedAt: now.Add(time.Hour),
+			},
+			expected: smsgateway.MessageState{
+				ID:          "msg-456",
+				DeviceID:    "device-2",
+				State:       smsgateway.ProcessingStateSent,
+				IsHashed:    true,
+				IsEncrypted: false,
+				Recipients: []smsgateway.RecipientState{
+					{PhoneNumber: "+1122334455", State: smsgateway.ProcessingStateSent},
+				},
+				States:      map[string]time.Time{string(messages.ProcessingStateSent): now},
+				DataMessage: &smsgateway.DataMessage{Data: "SGVsbG8gV29ybGQh", Port: uint16(53739)},
+				HashedMessage: &smsgateway.HashedMessage{
+					Hash: "1d4b6e3b1b6e3b1b6e3b1b6e3b1b6e3b1b6e3b1b",
+				},
+				CreatedAt: now.Add(time.Hour),
+			},
+		},
+		{
+			name:     "Minimal state with zero values",
+			input:    messages.MessageState{},
+			expected: smsgateway.MessageState{},
+		},
+	}
+
+	// Execute tests
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Call the function under test
+			result := converters.MessageStateToDTO(tc.input)
+
+			// Assert the results
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/sms-gateway/modules/messages/domain.go
+++ b/internal/sms-gateway/modules/messages/domain.go
@@ -55,7 +55,8 @@ type MessageState struct {
 	MessageStateInput
 	MessageStateContent
 
-	DeviceID    string `json:"deviceId"`    // Device ID
-	IsHashed    bool   `json:"isHashed"`    // Hashed
-	IsEncrypted bool   `json:"isEncrypted"` // Encrypted
+	DeviceID    string    `json:"deviceId"`    // Device ID
+	IsHashed    bool      `json:"isHashed"`    // Hashed
+	IsEncrypted bool      `json:"isEncrypted"` // Encrypted
+	CreatedAt   time.Time `json:"createdAt"`   // Created at
 }

--- a/internal/sms-gateway/modules/messages/models.go
+++ b/internal/sms-gateway/modules/messages/models.go
@@ -201,6 +201,7 @@ func (m *messageModel) toStateDomain() (*MessageState, error) {
 		DeviceID:    m.DeviceID,
 		IsHashed:    m.IsHashed,
 		IsEncrypted: m.IsEncrypted,
+		CreatedAt:   m.CreatedAt,
 	}, nil
 }
 

--- a/internal/sms-gateway/modules/messages/service.go
+++ b/internal/sms-gateway/modules/messages/service.go
@@ -258,13 +258,13 @@ func (s *Service) Enqueue(
 		return nil, err
 	}
 
+	if insErr := s.messages.Insert(msg); insErr != nil {
+		return nil, insErr
+	}
+
 	state, err := msg.toStateDomain()
 	if err != nil {
 		return nil, err
-	}
-
-	if insErr := s.messages.Insert(msg); insErr != nil {
-		return state, insErr
 	}
 
 	if cacheErr := s.cache.Set(

--- a/internal/sms-gateway/openapi/docs.go
+++ b/internal/sms-gateway/openapi/docs.go
@@ -1542,6 +1542,12 @@ const docTemplate = `{
                 "state"
             ],
             "properties": {
+                "createdAt": {
+                    "description": "Message creation time",
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2020-01-01T00:00:00Z"
+                },
                 "dataMessage": {
                     "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is data.",
                     "allOf": [
@@ -1579,6 +1585,14 @@ const docTemplate = `{
                     "description": "Hashed",
                     "type": "boolean",
                     "example": false
+                },
+                "mmsMessage": {
+                    "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is mms.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.MmsMessage"
+                        }
+                    ]
                 },
                 "recipients": {
                     "description": "Recipients states",
@@ -1975,11 +1989,20 @@ const docTemplate = `{
                     "maxLength": 65535,
                     "example": "Hello World!"
                 },
+                "mmsMessage": {
+                    "description": "MMS message",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.MmsMessage"
+                        }
+                    ]
+                },
                 "phoneNumbers": {
                     "description": "Recipients (phone numbers)",
                     "type": "array",
                     "maxItems": 100,
                     "minItems": 1,
+                    "uniqueItems": true,
                     "items": {
                         "type": "string"
                     },
@@ -2073,6 +2096,12 @@ const docTemplate = `{
                 "state"
             ],
             "properties": {
+                "createdAt": {
+                    "description": "Message creation time",
+                    "type": "string",
+                    "format": "date-time",
+                    "example": "2020-01-01T00:00:00Z"
+                },
                 "dataMessage": {
                     "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is data.",
                     "allOf": [
@@ -2110,6 +2139,14 @@ const docTemplate = `{
                     "description": "Hashed",
                     "type": "boolean",
                     "example": false
+                },
+                "mmsMessage": {
+                    "description": "Present only when ` + "`" + `includeContent=true` + "`" + ` and the message type is mms.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/smsgateway.MmsMessage"
+                        }
+                    ]
                 },
                 "recipients": {
                     "description": "Recipients states",
@@ -2155,6 +2192,52 @@ const docTemplate = `{
                 "LIFO",
                 "FIFO"
             ]
+        },
+        "smsgateway.MmsAttachment": {
+            "type": "object",
+            "required": [
+                "contentType",
+                "data"
+            ],
+            "properties": {
+                "contentType": {
+                    "description": "ContentType is the MIME type of the attachment.",
+                    "type": "string",
+                    "example": "image/png"
+                },
+                "data": {
+                    "description": "Data is the base64-encoded attachment content.",
+                    "type": "string",
+                    "example": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+                },
+                "name": {
+                    "description": "Name is the optional file name of the attachment.",
+                    "type": "string",
+                    "example": "picture.png"
+                }
+            }
+        },
+        "smsgateway.MmsMessage": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "description": "Attachments is the list of attachments. Omitted when empty.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/smsgateway.MmsAttachment"
+                    }
+                },
+                "subject": {
+                    "description": "Subject is the optional subject of the MMS.",
+                    "type": "string",
+                    "example": "Hello"
+                },
+                "text": {
+                    "description": "Text is the optional text body of the MMS.",
+                    "type": "string",
+                    "example": "World"
+                }
+            }
         },
         "smsgateway.ProcessingState": {
             "type": "string",

--- a/test/e2e/messages_test.go
+++ b/test/e2e/messages_test.go
@@ -369,7 +369,7 @@ func TestMessages_Post(t *testing.T) {
 				},
 			},
 			expectedStatusCode: 400,
-			expectedMessage:    "phone numbers must be unique",
+			expectedMessage:    "failed to validate: Key: 'Message.PhoneNumbers' Error:Field validation for 'PhoneNumbers' failed on the 'unique' tag",
 		},
 		{
 			name: "distinct phone numbers are accepted",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds `createdAt` to message-state domain and API responses and updates the generated client contract. It also reorders enqueue persistence before state conversion, but the database-generated timestamp remains unloaded.

- Propagates message creation time through state conversion and OpenAPI.
- Updates the client-go dependency and generated MMS-related contract fields.
- Adds converter and end-to-end expectation updates.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because successful enqueue responses and cached state can still contain a zero `createdAt`.

The insert succeeds, but `CreatedAt` is generated by MySQL and the service converts and caches the same model without reloading it, leaving the newly exposed field incorrect on the enqueue path.

**Files Needing Attention:** internal/sms-gateway/modules/messages/service.go and internal/sms-gateway/modules/messages/repository.go

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/sms-gateway/modules/messages/service.go | Moves insertion before conversion, but does not reload the database-generated timestamp before returning and caching state. |
| internal/sms-gateway/modules/messages/models.go | Correctly propagates the model's `CreatedAt` into the state domain, provided the model was loaded from storage. |
| internal/sms-gateway/handlers/converters/messages.go | Maps `CreatedAt` into the public DTO, thereby exposing the zero value retained by the enqueue path. |
| internal/sms-gateway/openapi/docs.go | Documents the new message-state timestamp and generated client contract additions. |
| internal/sms-gateway/handlers/converters/messages_test.go | Tests direct conversion with a manually populated timestamp but does not exercise database-generated enqueue values. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
internal/sms-gateway/modules/messages/service.go:265
**Inserted timestamp remains zero**

When a message is successfully enqueued, `Insert` generates `created_at` in MySQL but does not reload that read-only field into `msg`; converting and caching the same in-memory model therefore returns `0001-01-01T00:00:00Z` in the accepted response and subsequent cached state reads.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["\[messages\] expose \`createdAt\` field in s..."](https://github.com/android-sms-gateway/server/commit/bba39d42c51b49c0eea39088994139729716c409) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58301903)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [SMS message delivery lifecycle](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/android-sms-gateway/server/-/docs/message-delivery-lifecycle.md)
- Knowledge Base — [API contracts and external integrations](https://app.greptile.com/smsgate-app/-/custom-context/knowledge-base/android-sms-gateway/server/-/docs/api-contracts-and-integrations.md)

<!-- /greptile_comment -->